### PR TITLE
Add scaladia-http / Support recovery injection.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,16 +34,20 @@ releaseProcess := Seq[ReleaseStep](
 )
 lazy val root = project.in(file("."))
   .aggregate(
-    injectorCore
+    scaladiaInjectorCore,
+    scaladiaHttp
   )
-  .dependsOn(injectorCore)
+  .dependsOn(
+    scaladiaInjectorCore,
+    scaladiaHttp
+  )
   .settings(assemblySettings)
   .settings(
     name := "scaladia",
     description := "Scaladia all libraries."
   )
 
-lazy val injectorCore = (project in file("scaladia-container-core"))
+lazy val scaladiaInjectorCore = (project in file("scaladia-container-core"))
   .settings(assemblySettings)
   .settings(
     name := "scaladia-container-core",
@@ -53,6 +57,18 @@ lazy val injectorCore = (project in file("scaladia-container-core"))
       "org.scala-lang" % "scala-reflect" % "2.12.4",
       "org.slf4j" % "slf4j-api" % "1.7.25",
       "org.scalatest" %% "scalatest" % "3.0.5" % Test
+    )
+  )
+
+lazy val scaladiaHttp = (project in file("scaladia-http"))
+  .dependsOn(scaladiaInjectorCore)
+  .settings(assemblySettings)
+  .settings(
+    name := "scaladia-http",
+    description := "Http client for Scala.",
+    libraryDependencies ++= Seq(
+      "org.dispatchhttp" %% "dispatch-core" % "0.14.0",
+      "com.twitter" %% "finatra-http" % "18.4.0"
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,13 @@ lazy val assemblySettings = Seq(
   scalacOptions in Test ++= Seq("-Yrangepos", "-Xlint", "-deprecation", "-unchecked", "-feature"),
   releaseCrossBuild := true,
   crossScalaVersions := Seq("2.11.12", "2.12.4"),
-  licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))
+  licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html")),
+  assemblyMergeStrategy in assembly := {
+    case PathList(ps@_*) if ps.last endsWith ".class"      => MergeStrategy.first
+    case PathList(ps@_*) if ps.last endsWith "BUILD"       => MergeStrategy.first
+    case PathList(ps@_*) if ps.last endsWith ".properties" => MergeStrategy.first
+    case ps                                                => (assemblyMergeStrategy in assembly).value(ps)
+  }
 )
 
 releaseProcess := Seq[ReleaseStep](

--- a/scaladia-container-core/src/main/scala/com/giitan/box/Container.scala
+++ b/scaladia-container-core/src/main/scala/com/giitan/box/Container.scala
@@ -22,7 +22,7 @@ object Container {
       * @tparam S
       * @return
       */
-    private[giitan] def find[T: TypeTag : ClassTag, S <: Injector : TypeTag](tag: TypeTag[T], scope: S): StoredDependency[T] = new Reflector(tag, scope)
+    private[giitan] def find[T: TypeTag : ClassTag, S <: Injector : TypeTag](tag: TypeTag[T], scope: S): StoredDependency[T] = Reflector(tag, scope)
   }
 
 }

--- a/scaladia-container-core/src/main/scala/com/giitan/injectable/StoredDependency.scala
+++ b/scaladia-container-core/src/main/scala/com/giitan/injectable/StoredDependency.scala
@@ -1,8 +1,26 @@
 package com.giitan.injectable
 
 trait StoredDependency[X] {
-  protected var lazyProvided: Option[X] = None
+  /**
+    * Dependency search function.
+    */
   protected val dependencyGet: () => X
+  /**
+    * Recovery hook when failure of dependency search fails.
+    */
+  protected val recoverHook: PartialFunction[Throwable, X]
+  /**
+    * Delayed evaluated Object container.
+    */
+  protected var lazyProvided: Option[X] = None
+
+  /**
+    * Recovery hook when failure of dependency search fails.
+    *
+    * @param function Recovery hook.
+    * @return
+    */
+  def recover(function: PartialFunction[Throwable, X]): StoredDependency[X]
 
   /**
     * Provide dependency and make it persistent.

--- a/scaladia-container-core/src/test/scala/com/giitan/inject/InjectorTest.scala
+++ b/scaladia-container-core/src/test/scala/com/giitan/inject/InjectorTest.scala
@@ -1,21 +1,28 @@
 package com.giitan.inject
 
-import com.giitan.inject.InjectorTest._
+import com.giitan.inject.InjectorTest.{A, _}
 import com.giitan.injector.Injector
 import org.scalatest.{Assertion, Matchers, WordSpec}
 
+import scala.util.{Failure, Success, Try}
+
 object InjectorTest {
+
   trait A
-  object B extends A
-  object C extends A
 
   trait X
-  object Y extends X
-  object Z extends X
 
   trait Named {
     def name: Int
   }
+
+  object B extends A
+
+  object C extends A
+
+  object Y extends X
+
+  object Z extends X
 
   object Named1 extends Named {
     def name = 1
@@ -24,9 +31,16 @@ object InjectorTest {
   object Named2 extends Named {
     def name = 2
   }
+
 }
 
-class InjectorTest extends WordSpec with Matchers { me =>
+object InjectorTest_RECOVER_CASE {
+  trait A
+  object B extends A
+}
+
+class InjectorTest extends WordSpec with Matchers {
+  me =>
 
   "Injector test" should {
 
@@ -67,6 +81,21 @@ class InjectorTest extends WordSpec with Matchers { me =>
 
       ExecuteB.test()
       ExecuteY.test()
+    }
+
+    "Un recovery injection" in new Injector {
+      Try {
+        inject[InjectorTest_RECOVER_CASE.A].provide
+      } match {
+        case Success(_) => fail()
+        case Failure(_) => succeed
+      }
+    }
+
+    "Recovery injection" in new Injector {
+      inject[InjectorTest_RECOVER_CASE.A].recover {
+        case _ => InjectorTest_RECOVER_CASE.B
+      }.provide shouldBe InjectorTest_RECOVER_CASE.B
     }
   }
 }

--- a/scaladia-http/README.md
+++ b/scaladia-http/README.md
@@ -1,0 +1,34 @@
+# scaladia-http
+
+## How to use
+
+```
+libraryDependencies += "com.github.giiita" %% "scaladia" % "1.3.0"
+````
+
+## Examples
+
+### HTTP Server call
+
+```
+import com.github.giiita.io.http.Http._
+
+object MySetting extends HttpRequestSetting(retryThreshold = 3) with AutoInject[HttpRequestSetting]
+
+val requets = Map(
+  "id" -> 1,
+  "name" -> "Jack"
+)
+
+val result: Future[FutureSearch.Response] =
+  http[GET](s"http://localhost:80/?${requets.asUrl}")
+    .header("auth", "abcde")
+    .deserializing[ResponseType]
+    .map(_.value)
+    .flatMap(FutureSearch.byValue)
+    .run
+```
+
+HttpRequestSetting is always reflected when making a request.
+When changing, AutoInject injection is possible.
+

--- a/scaladia-http/src/main/scala/com/github/giiita/io/http/Http.scala
+++ b/scaladia-http/src/main/scala/com/github/giiita/io/http/Http.scala
@@ -1,0 +1,182 @@
+package com.github.giiita.io.http
+
+import com.giitan.injector.Injector
+import com.github.giiita.io.http.setting.HttpRequestSetting
+import dispatch.{url, _}
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.util.{Failure, Success, Try}
+
+object Http extends Injector {
+  private lazy final val URL_PARAM_FORMAT = "%s=%s"
+  private val logger: Logger = LoggerFactory.getLogger(this.getClass)
+
+  implicit class UrlParameters(value: Map[String, Any]) {
+    /**
+      * Convert to get request string.
+      *
+      * @return "x=y&a=b&1=2"
+      */
+    def asUrl: String = {
+      value.map { x =>
+        URL_PARAM_FORMAT.format(x._1, x._2.toString)
+      }.mkString("&")
+    }
+  }
+
+  /**
+    * Create a http request task.
+    * {{{
+    *   import com.github.giiita.io.http.Http._
+    *
+    *   val requets = Map(
+    *     "id" -> 1,
+    *     "name" -> "Jack"
+    *   )
+    *
+    *   val result: FutureSearch.Response =
+    *     http[GET](s"http://localhost:80/?${requets.asUrl}")
+      *     .header("auth", "abcde")
+      *     .deserializing[ResponseType]
+      *     .map(_.value)
+      *     .flatMap(FutureSearch.byValue)
+      *     .run
+    * }}}
+    *
+    * @param urlString Request url
+    * @tparam T Request method type. See [[com.github.giiita.io.http.HttpMethod]]
+    * @return
+    */
+  def http[T <: HttpMethod.Method : MethodType](urlString: String): HttpBuilderTask = {
+    logger.info(s"Setup http request [ $urlString ]")
+
+    val setting = inject[HttpRequestSetting].recover {
+      case _ => new HttpRequestSetting()
+    }
+
+    new HttpBuilderTask(
+      implicitly[MethodType[T]].method(
+        setting.globalHeader
+          .foldLeft(url(urlString))((x, y) => x.setHeader(y.name, y.value.toString))
+          .setBodyEncoding(setting.bodyEncoding)
+      ),
+      setting
+    )
+  }
+}
+
+private object HttpBuilderTask extends Injector {
+
+  private lazy final val RETRY = 2
+  private val logger: Logger = LoggerFactory.getLogger(this.getClass)
+
+  /**
+    * Http request executor with retry.
+    *
+    * @param retry Max retry count.
+    * @param func  Execution.
+    * @tparam R Return type.
+    * @return
+    */
+  private def retryRequest[R](retry: Int = 1)(func: => Future[R]): Future[R] = {
+    func.transform {
+      case Success(x)                   =>
+        Success(Future(x))
+      case Failure(x) if retry >= RETRY =>
+        logger.error(s"Request retry failed.", x)
+        Failure(x)
+      case Failure(x)                   =>
+        logger.warn(s"Request retry failed. ${x.getMessage}")
+        Try(retryRequest(retry + 1)(func))
+    }.flatten
+  }
+}
+
+sealed class HttpBuilderTask(request: Req, setting: HttpRequestSetting) extends JacksonParser {
+  /**
+    * Set a request body.
+    *
+    * @param value Request body. It will be serialized by Jackson.
+    * @tparam T Request body type.
+    * @return
+    */
+  def body[T](value: T): HttpBuilderTask = new HttpBuilderTask(
+    request.setBody(serialize(value)),
+    setting
+  )
+
+  /**
+    * Set a requets header.
+    *
+    * @param key   header key
+    * @param value header value
+    * @return
+    */
+  def header(key: String, value: String): HttpBuilderTask = new HttpBuilderTask(
+    request.setHeader(key, value),
+    setting
+  )
+
+  /**
+    * Regist a type of returning deserialized json texts.
+    *
+    * @tparam T Deserialized type.
+    * @return
+    */
+  def deserializing[T]: HttpRunner[T] = new HttpRunner[T](
+    () => HttpBuilderTask.retryRequest() {
+      val cli = dispatch.Http(dispatch.Http.defaultClientBuilder.setRequestTimeout(setting.timeout))
+      cli(request.OK(as.String)).map { x =>
+        cli.client.close()
+        x
+      }.map(deserialize)
+    }
+  )
+}
+
+sealed class HttpRunner[T](request: HttpResultTask[T]) extends JacksonParser {
+  /**
+    * To synthesize.
+    *
+    * @param func Synthesis processing.
+    * @tparam R Synthesize return type.
+    * @return
+    */
+  def map[R](func: T => R): HttpRunner[R] = new HttpRunner(() => run.map(func))
+
+  /**
+    * To flatten synthesize.
+    *
+    * @param func Synthesis processing.
+    * @tparam R Synthesize return type.
+    * @return
+    */
+  def flatMap[R](func: T => Future[R]): HttpRunner[R] = new HttpRunner(() => run.flatMap(func))
+
+  /**
+    * Execute future functions.
+    *
+    * @return
+    */
+  def run: Future[T] = request.execute()
+}
+
+trait HttpResultTask[T] extends JacksonParser {
+  def execute(): Future[T]
+}
+
+object HttpMethod {
+
+  abstract class Method
+
+  class GET extends Method
+
+  class PUT extends Method
+
+  class POST extends Method
+
+  class DELETE extends Method
+
+}

--- a/scaladia-http/src/main/scala/com/github/giiita/io/http/JacksonParser.scala
+++ b/scaladia-http/src/main/scala/com/github/giiita/io/http/JacksonParser.scala
@@ -1,0 +1,33 @@
+package com.github.giiita.io.http
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.giitan.injector.Injector
+
+import scala.reflect.ClassTag
+
+object JacksonParser {
+  val jackson: ObjectMapper = new ObjectMapper().registerModule(DefaultScalaModule)
+}
+
+trait JacksonParser extends Injector {
+  /**
+    * Serialize to json string.
+    *
+    * @param v Serialized value.
+    * @tparam T Serialized value type.
+    * @return
+    */
+  def serialize[T](v: T): String = JacksonParser.jackson.writeValueAsString(v)
+
+  /**
+    * Serialize from json string
+    *
+    * @param v JsonString
+    * @tparam T Response type.
+    * @return
+    */
+  def deserialize[T: ClassTag](v: String): T = {
+    JacksonParser.jackson.readValue(v, implicitly[ClassTag[T]].runtimeClass.asInstanceOf[Class[T]])
+  }
+}

--- a/scaladia-http/src/main/scala/com/github/giiita/io/http/package.scala
+++ b/scaladia-http/src/main/scala/com/github/giiita/io/http/package.scala
@@ -1,0 +1,14 @@
+package com.github.giiita.io
+
+import com.github.giiita.io.http.HttpMethod.{DELETE, GET, POST, PUT}
+import dispatch.Req
+
+package object http {
+
+  class MethodType[T <: HttpMethod.Method](val method: Req => Req)
+
+  implicit case object GET extends MethodType[GET](_.GET)
+  implicit case object PUT extends MethodType[PUT](_.PUT)
+  implicit case object POST extends MethodType[POST](_.POST)
+  implicit case object DELETE extends MethodType[DELETE](_.DELETE)
+}

--- a/scaladia-http/src/main/scala/com/github/giiita/io/http/setting/Header.scala
+++ b/scaladia-http/src/main/scala/com/github/giiita/io/http/setting/Header.scala
@@ -1,0 +1,9 @@
+package com.github.giiita.io.http.setting
+
+/**
+  * Request header class.
+  *
+  * @param name Header name
+  * @param value Header value
+  */
+case class Header(name: String, value: Any)

--- a/scaladia-http/src/main/scala/com/github/giiita/io/http/setting/HttpRequestSetting.scala
+++ b/scaladia-http/src/main/scala/com/github/giiita/io/http/setting/HttpRequestSetting.scala
@@ -1,0 +1,21 @@
+package com.github.giiita.io.http.setting
+
+import java.nio.charset.{Charset, StandardCharsets}
+
+/**
+  * Settings that are always reflected when making a request.
+  * When changing, AutoInject injection is possible.
+  *
+  * {{{
+  *   object MySetting extends HttpRequestSetting(retryThreshold = 3) with AutoInject[HttpRequestSetting]
+  * }}}
+  *
+  * @param retryThreshold Retry threshold. When 2 is set, up to one failure is allowed.
+  * @param globalHeader   The header set here will be given to all requests.
+  * @param bodyEncoding   Body encoding charset.
+  * @param timeout        Request timeout milliseconds.
+  */
+class HttpRequestSetting(val retryThreshold: Int = 1,
+                         val globalHeader: Seq[Header] = Seq(Header("Content-type", "application/json")),
+                         val bodyEncoding: Charset = StandardCharsets.UTF_8,
+                         val timeout: Int = 30 * 1000)

--- a/scaladia-http/version.sbt
+++ b/scaladia-http/version.sbt
@@ -1,0 +1,1 @@
+version in ThisProject := "0.0.1-SNAPSHOT"


### PR DESCRIPTION
## Add scaladia-http

Add HTTP request client.

```
import com.github.giiita.io.http.Http._

object MySetting extends HttpRequestSetting(retryThreshold = 3) with AutoInject[HttpRequestSetting]

val requets = Map(
  "id" -> 1,
  "name" -> "Jack"
)

val result: FutureSearch.Response =
  http[GET](s"http://localhost:80/?${requets.asUrl}")
    .header("auth", "abcde")
    .deserializing[ResponseType]
    .map(_.value)
    .flatMap(FutureSearch.byValue)
    .run
```

## Support recovery injection

Supports restoration when dependency injection fails with specific error.

```
inject[HttpRequestSetting].recover {
  case _ => new HttpRequestSetting()
}
```