### PR TITLE
sbt version upgrade / fix build failure with empty sub module.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ lazy val all = (project in file("scaladia-all"))
   .settings(
     name := "scaladia",
     description := "Scaladia all libraries.",
-    version in ThisProject := "1.5.6"
+    version in ThisProject := "1.5.7"
   )
 
 lazy val scaladiaContainerCore = (project in file("scaladia-container-core"))
@@ -71,7 +71,7 @@ lazy val scaladiaContainerCore = (project in file("scaladia-container-core"))
       "org.slf4j" % "slf4j-api" % "1.7.25",
       "org.scalatest" %% "scalatest" % "3.0.5" % Test
     ),
-    version in ThisProject := "1.5.6-SNAPSHOT"
+    version in ThisProject := "1.5.6"
   )
 
 lazy val scaladiaHttp = (project in file("scaladia-http"))

--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,7 @@ lazy val scaladiaContainerCore = (project in file("scaladia-container-core"))
       "org.slf4j" % "slf4j-api" % "1.7.25",
       "org.scalatest" %% "scalatest" % "3.0.5" % Test
     ),
-    version in ThisProject := "1.5.5"
+    version in ThisProject := "1.5.6-SNAPSHOT"
   )
 
 lazy val scaladiaHttp = (project in file("scaladia-http"))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.2.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.7")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.4")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.13.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")

--- a/scaladia-container-core/README.md
+++ b/scaladia-container-core/README.md
@@ -3,7 +3,7 @@
 ## How to use
 
 ```
-libraryDependencies += "com.github.giiita" %% "scaladia" % "1.5.5"
+libraryDependencies += "com.github.giiita" %% "scaladia" % "1.5.7"
 ````
 
 ## Supports full scanning injection (v1.5.0 ~)

--- a/scaladia-container-core/src/main/scala/com/giitan/lang/RuntimeTZ.scala
+++ b/scaladia-container-core/src/main/scala/com/giitan/lang/RuntimeTZ.scala
@@ -11,7 +11,7 @@ object RuntimeTZ extends RuntimeTZ {
   override val DEFAULT_FORMAT: String = "yyyy/M/d H:m:s Z"
 }
 
-object AsiaTokyoTZ extends RuntimeTZ {
+class AsiaTokyoTZ extends RuntimeTZ {
   override val TIME_ZONE: TimeZone = TimeZone.getTimeZone("Asia/Tokyo")
   override val ZONE_ID: ZoneId = ZoneId.of("Asia/Tokyo")
   override val ZONE_OFFSET: ZoneOffset = ZoneOffset.ofHours(9)

--- a/scaladia-http/README.md
+++ b/scaladia-http/README.md
@@ -3,7 +3,7 @@
 ## How to use
 
 ```
-libraryDependencies += "com.github.giiita" %% "scaladia" % "1.5.4"
+libraryDependencies += "com.github.giiita" %% "scaladia" % "1.5.7"
 ````
 
 ## Examples


### PR DESCRIPTION
## Update sbt version

sbt 0.13 => sbt 1.2.6

## Fix build bug

Throws NullPointerException when building a project with empty submodules.
