### PR TITLE
Full scan mode default true.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
 
     environment:
       # Customize the JVM maximum heap limit
-      JVM_OPTS: -Xmx3200m
+      JVM_OPTS: -Xmx5g
       TERM: dumb
 
     steps:
@@ -29,7 +29,7 @@ jobs:
       - run:
           name: Full version build
           command: |
-            sbt +clean +compile +test
+            sbt -mem 4000 +clean +compile +test
           no_output_timeout: 60m
 
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ jobs:
           name: Full version build
           command: |
             sbt +clean +compile +test
+          no_output_timeout: 60m
 
       - save_cache:
           paths:

--- a/build.sbt
+++ b/build.sbt
@@ -42,6 +42,7 @@ lazy val root = project.in(file("."))
     scaladiaHttp,
     all
   ).settings(
+    publishLocal in ThisProject := {},
     publishArtifact in ThisProject := false,
     scalaVersion := GLOBAL_SCALA_VERSION,
     crossScalaVersions := Seq("2.11.12", "2.12.8")
@@ -56,7 +57,7 @@ lazy val all = (project in file("scaladia-all"))
   .settings(
     name := "scaladia",
     description := "Scaladia all libraries.",
-    version in ThisProject := "1.5.7"
+    version in ThisProject := "1.6.0"
   )
 
 lazy val scaladiaContainerCore = (project in file("scaladia-container-core"))
@@ -69,9 +70,10 @@ lazy val scaladiaContainerCore = (project in file("scaladia-container-core"))
       "com.typesafe" % "config" % "1.3.2",
       "org.scala-lang" % "scala-reflect" % "2.12.8",
       "org.slf4j" % "slf4j-api" % "1.7.25",
+      "org.slf4j" % "slf4j-simple" % "1.7.25",
       "org.scalatest" %% "scalatest" % "3.0.5" % Test
     ),
-    version in ThisProject := "1.5.6"
+    version in ThisProject := "1.5.7"
   )
 
 lazy val scaladiaHttp = (project in file("scaladia-http"))

--- a/scaladia-container-core/README.md
+++ b/scaladia-container-core/README.md
@@ -3,10 +3,10 @@
 ## How to use
 
 ```
-libraryDependencies += "com.github.giiita" %% "scaladia" % "1.5.7"
+libraryDependencies += "com.github.giiita" %% "scaladia" % "1.6.0"
 ````
 
-## Supports full scanning injection (v1.5.0 ~)
+## Supports full scanning injection (v1.5.0 ~) (Default true from v1.6.0 ~)
 
 Until now it was a premise to use it with FatJar (sbt-assembly).<br/>
 AutoInjectScan was supported only from the archive that Scaladia package was shipped with.
@@ -27,6 +27,7 @@ For whitelist, set loadable archives name (broad match).<br/>
 If you omit the whitelist, you will load archives such as jre and scala-lang, so the performance immediately after starting Application will degrade.<br/>
 Even if fullscan is false, AutoInject of the current class loader will be loaded.
 
+It defaults to `true` from `1.6.0 ~`.
 
 ## Examples
 
@@ -115,6 +116,13 @@ object TestA extends Injector {
   }
 }
 ```
+
+When overwriting with a limited scope in the test, We recommend it.<br>
+```
+narrow[T](new T).accept(this).indexing()
+```
+Overwriting with `depends` and running tests in parallel may unexpectedly overwrite globally.
+
 
 ### Custom usage
 

--- a/scaladia-container-core/src/main/scala/com/giitan/box/ScaladiaAutoDIConfigSet.scala
+++ b/scaladia-container-core/src/main/scala/com/giitan/box/ScaladiaAutoDIConfigSet.scala
@@ -2,6 +2,7 @@ package com.giitan.box
 
 import java.net.URL
 
+import com.giitan.box.ScaladiaClassLoader.logger
 import com.giitan.loader.StringURIConvertor._
 import com.typesafe.config.ConfigFactory
 import org.slf4j.LoggerFactory
@@ -14,14 +15,26 @@ private[giitan] object ScaladiaAutoDIConfigSet {
   private lazy val SCALADIA_CONFIG_SET_PATH = "scaladia"
   private lazy val LOAD_MULTI_CLASSPATHSET = "fullscan"
   private lazy val SCANING_ARCHIVE_WHITELIST = "whitelist"
+  private lazy val SCANING_ARCHIVE_BLACKLIST = "blacklist"
+
   private lazy val isMultiClassPathMode: Boolean = Try {
     configSet.getBoolean(s"$SCALADIA_CONFIG_SET_PATH.$LOAD_MULTI_CLASSPATHSET")
-  }.getOrElse(false)
+  }.getOrElse(true)
+
   private lazy val scanningArchiveWhitelist: Seq[String] = {
     Try {
       configSet.getStringList(s"$SCALADIA_CONFIG_SET_PATH.$SCANING_ARCHIVE_WHITELIST").asScala
     }.getOrElse(Nil)
   }
+
+  private lazy val scanningArchiveBlacklist: Seq[String] = {
+    Try {
+      configSet.getStringList(s"$SCALADIA_CONFIG_SET_PATH.$SCANING_ARCHIVE_BLACKLIST").asScala
+    }.getOrElse(
+      Seq(".jdk")
+    )
+  }
+
   private val logger = LoggerFactory.getLogger(this.getClass)
   private val configSet = ConfigFactory.load()
 

--- a/scaladia-container-core/src/main/scala/com/giitan/box/ScaladiaClassLoader.scala
+++ b/scaladia-container-core/src/main/scala/com/giitan/box/ScaladiaClassLoader.scala
@@ -20,6 +20,7 @@ object ScaladiaClassLoader {
     accessibleProtocolResolve(ucl.fold[List[URL]](Nil)(_.getURLs.toList))
       .scanAccepted(classLoader)
       .distinct
+      .par
       .map(findClassesWithFile(_, rootPackageName)) match {
       case x if x.isEmpty => ClassCrowds()
       case x              => x.reduceLeft(_ +++ _)
@@ -29,6 +30,7 @@ object ScaladiaClassLoader {
   private def findClassesWithFile(x: URL, rootPackageName: String): ClassCrowds = {
     logger.debug(s"Injectable set loading from ${x.getProtocol}:${x.getPath}")
     x match {
+      case url if url.getPath.contains(".jdk") => ClassCrowds()
       case url if url.getProtocol == "file" => new File(x.getFile).classCrowdEntries(rootPackageName)
       case url if url.getProtocol == "jar"  =>
 

--- a/scaladia-container-core/src/main/scala/com/giitan/container/Reflector.scala
+++ b/scaladia-container-core/src/main/scala/com/giitan/container/Reflector.scala
@@ -21,7 +21,7 @@ case class Reflector[T: TypeTag : ClassTag, S <: Injector : TypeTag](tag: TypeTa
         implicitly[Container[ClassScope]].search(tag, scope.getClass)
       ) getOrElse {
       throw new InjectableDefinitionException(
-        s"""${tag.tpe} or internal dependencies injected failed.""".stripMargin
+        s"""Cannot found ${tag.tpe} implementation.""".stripMargin
       )
     }
   }

--- a/scaladia-container-core/src/main/scala/com/giitan/container/package.scala
+++ b/scaladia-container-core/src/main/scala/com/giitan/container/package.scala
@@ -1,6 +1,7 @@
 package com.giitan
 
 import com.giitan.box.{Container, ScaladiaClassLoader}
+import com.giitan.exception.StaticInitializationException
 import com.giitan.injectable.InjectableSet._
 import com.giitan.injectable.{Injectable, InjectableConversion}
 import com.giitan.injector.Injector
@@ -13,6 +14,7 @@ import scala.collection.mutable.ListBuffer
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
+import scala.util.Failure
 
 package object container {
 
@@ -44,7 +46,12 @@ package object container {
       */
     def search[T: TypeTag : ClassTag, S <: Injector : TypeTag](tag: TypeTag[T], scope: ClassScope[S]): Option[T] = {
       container.searchAccessibleOne[T](tag.tpe, scope) orElse {
-        AutomaticContainerInitializer.initialize[T]()
+        scala.util.Try {
+          AutomaticContainerInitializer.initialize[T]()
+        } match {
+          case Failure(e) => throw new StaticInitializationException(s"${tag.tpe} initialize failed.", e)
+          case _ =>
+        }
         container.searchAccessibleOne[T](tag.tpe, scope)
       }
     }

--- a/scaladia-container-core/version.sbt
+++ b/scaladia-container-core/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "1.5.5"


### PR DESCRIPTION
When executing with sbt 1 system or executing it with multiple class paths, there was a problem that dependency of a specific external archive could not be loaded unless conf was set.
scaladia 1.6.0 or later, full scan mode be true default.To optimize, add a whitelist.
```
scaladia {
  whitelist = ["-mycompany-lib"]
}
```
This is necessary to run it with sbt shell when it is over `sbt1` or to run it from the IDE.