### PR TITLE
Fix class loader bug.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,7 @@ lazy val all = (project in file("scaladia-all"))
   .settings(
     name := "scaladia",
     description := "Scaladia all libraries.",
-    version in ThisProject := "1.6.0"
+    version in ThisProject := "1.6.1"
   )
 
 lazy val scaladiaContainerCore = (project in file("scaladia-container-core"))
@@ -73,7 +73,7 @@ lazy val scaladiaContainerCore = (project in file("scaladia-container-core"))
       "org.slf4j" % "slf4j-simple" % "1.7.25",
       "org.scalatest" %% "scalatest" % "3.0.5" % Test
     ),
-    version in ThisProject := "1.5.8-SNAPSHOT"
+    version in ThisProject := "1.5.8"
   )
 
 lazy val scaladiaHttp = (project in file("scaladia-http"))

--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ lazy val scaladiaContainerCore = (project in file("scaladia-container-core"))
       "org.slf4j" % "slf4j-simple" % "1.7.25",
       "org.scalatest" %% "scalatest" % "3.0.5" % Test
     ),
-    version in ThisProject := "1.5.7"
+    version in ThisProject := "1.5.8-SNAPSHOT"
   )
 
 lazy val scaladiaHttp = (project in file("scaladia-http"))

--- a/scaladia-container-core/src/main/scala/com/giitan/box/ScaladiaClassLoader.scala
+++ b/scaladia-container-core/src/main/scala/com/giitan/box/ScaladiaClassLoader.scala
@@ -13,7 +13,7 @@ import scala.annotation.tailrec
 object ScaladiaClassLoader {
   private val URL_CLASSLOADER_DEPTH_LIMIT = 5
   private val logger = LoggerFactory.getLogger(getClass)
-  private[giitan] val classLoader: ClassLoader = Thread.currentThread().getContextClassLoader
+  private[giitan] val classLoader: ClassLoader = getClass.getClassLoader
 
   private[giitan] def findClasses(rootPackageName: String = ""): ClassCrowds = {
     val ucl = getUrlClassloader(classLoader)

--- a/scaladia-container-core/src/main/scala/com/giitan/container/package.scala
+++ b/scaladia-container-core/src/main/scala/com/giitan/container/package.scala
@@ -46,11 +46,12 @@ package object container {
       */
     def search[T: TypeTag : ClassTag, S <: Injector : TypeTag](tag: TypeTag[T], scope: ClassScope[S]): Option[T] = {
       container.searchAccessibleOne[T](tag.tpe, scope) orElse {
+
         scala.util.Try {
           AutomaticContainerInitializer.initialize[T]()
         } match {
           case Failure(e) => throw new StaticInitializationException(s"${tag.tpe} initialize failed.", e)
-          case _ =>
+          case _          => logger.debug(s"${tag.tpe} initialize success.")
         }
         container.searchAccessibleOne[T](tag.tpe, scope)
       }
@@ -110,4 +111,5 @@ package object container {
   private[giitan] object TaggedContainer {
     val automaticDependencies: ClassCrowds = ScaladiaClassLoader.findClasses()
   }
+
 }


### PR DESCRIPTION
Fixed the bug that loading fullscaning settings from unexpected class loader when running `sbt test` in parallel in multi-project configuration

```
root
  sub-module-A
    src/test/resources/reference.conf
      whitelist = ["aaa", "bbb"]
  sub-module-B
    src/test/resources/reference.conf
      whitelist = ["aaa", "ccc"]
  sub-module-C
    src/test/resources/reference.conf
      whitelist = ["ddd", "eee"]
```
Rarely this happens.
```
> sbt root/test
  => The whitelist loaded by A is ["aaa", "bbb"]
  => The whitelist loaded by B is ["aaa", "bbb"]
  => The whitelist loaded by C is ["ddd", "eee"]
```