### PR TITLE
v2.1.2 Delayed initialization at runtime.

### DIFF
--- a/scaladia-container/README.md
+++ b/scaladia-container/README.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```
-libraryDependencies += "com.phylage" %% "scaladia-container" % "2.1.0"
+libraryDependencies += "com.phylage" %% "scaladia-container" % "2.1.2"
 ````
 
 ### Simplest Injection

--- a/scaladia-container/src/main/scala/com/phylage/scaladia/container/ContainerStore.scala
+++ b/scaladia-container/src/main/scala/com/phylage/scaladia/container/ContainerStore.scala
@@ -1,5 +1,8 @@
 package com.phylage.scaladia.container
 
+import com.phylage.scaladia.injector.InjectionPool
+
 private[scaladia] trait ContainerStore {
   val ctn: Container
+  val ijp: InjectionPool
 }

--- a/scaladia-container/src/main/scala/com/phylage/scaladia/container/InjectionPool.scala
+++ b/scaladia-container/src/main/scala/com/phylage/scaladia/container/InjectionPool.scala
@@ -1,0 +1,38 @@
+package com.phylage.scaladia.container
+
+import com.phylage.scaladia.injector.{InjectionPool, InjectionType}
+
+import scala.collection.mutable.ListBuffer
+import scala.reflect.runtime.universe._
+
+object InjectionPool extends InjectionPool {
+  private[this] val buffer: ListBuffer[InjectionType[_]] = ListBuffer()
+
+  /**
+    * Pool Injectable subtypes for automatic loading.
+    * The timing to be initialized is when the related
+    * component is initialized or when it is called by inject.
+    *
+    * @param value injection object
+    * @tparam T injection type
+    * @return
+    */
+  def pool[T](value: InjectionType[T]): Unit = {
+    if (!buffer.contains(value)) buffer += value
+  }
+
+  /**
+    * Get a list of injection-enabled declarations of any type
+    *
+    * @param wtt weak type tag.
+    * @tparam T Type you are trying to get
+    * @return
+    */
+  def collect[T](implicit wtt: WeakTypeTag[T]): Vector[InjectionApplyment[T]] = {
+    {
+      buffer.collect {
+        case x if wtt.tpe.=:=(x.wtt.tpe) => x
+      } map {_.applyment}
+    }.toVector.asInstanceOf[Vector[InjectionApplyment[T]]]
+  }
+}

--- a/scaladia-container/src/main/scala/com/phylage/scaladia/injector/AutoInject.scala
+++ b/scaladia-container/src/main/scala/com/phylage/scaladia/injector/AutoInject.scala
@@ -11,7 +11,7 @@ import com.phylage.scaladia.injector.scope.InjectableScope
   *
   * @tparam T Type to register
   */
-trait AutoInject[T] extends AutoInjectable with Injector {
+trait AutoInject[T] extends AutoInjectable[T] with Injector {
   me: T =>
 
   private[scaladia] val injectionPriority = 1000

--- a/scaladia-container/src/main/scala/com/phylage/scaladia/injector/Injector.scala
+++ b/scaladia-container/src/main/scala/com/phylage/scaladia/injector/Injector.scala
@@ -51,7 +51,7 @@ trait Injector {
     * @tparam T Injection type
     * @return
     */
-  protected def inject[T](implicit ctn: Container, access: Accessor[_]): Lazy[T] = macro Macro.lazyInject[T]
+  protected def inject[T](implicit ctn: Container, ip: InjectionPool, access: Accessor[_]): Lazy[T] = macro Macro.lazyInject[T]
 
 
   /**
@@ -70,7 +70,7 @@ trait Injector {
     * @tparam T Injection type
     * @return
     */
-  protected def confirm[T](implicit ctn: Container, access: Accessor[_]): T = macro Macro.diligentInject[T]
+  protected def confirm[T](implicit ctn: Container, ip: InjectionPool, access: Accessor[_]): T = macro Macro.diligentInject[T]
 
   /**
     * Provide dependency.
@@ -85,13 +85,19 @@ trait Injector {
     * This refers to itself
     * @return
     */
-  protected implicit def from: Accessor[_] = Accessor(me)
+  protected implicit def someoneNeeds: Accessor[_] = Accessor(me)
 
   /**
     * Implicitly container
     * @return
     */
-  protected implicit def getContainer: Container = implicitly[ContainerStore].ctn
+  protected implicit def _dicnt: Container = implicitly[ContainerStore].ctn
+
+  /**
+    * Implicitly injection pool
+    * @return
+    */
+  protected implicit def _ijp: InjectionPool = implicitly[ContainerStore].ijp
 
 
 }

--- a/scaladia-container/src/main/scala/com/phylage/scaladia/injector/package.scala
+++ b/scaladia-container/src/main/scala/com/phylage/scaladia/injector/package.scala
@@ -1,6 +1,6 @@
 package com.phylage.scaladia
 
-import com.phylage.scaladia.container.{Container, ContainerStore, DefaultContainer}
+import com.phylage.scaladia.container.{Container, ContainerStore, DefaultContainer, InjectionPool}
 
 package object injector {
 
@@ -8,6 +8,8 @@ package object injector {
     lazy val ctn: Container = initContainer
 
     def initContainer: Container = DefaultContainer
+
+    override val ijp: InjectionPool = InjectionPool
   }
 
 }

--- a/scaladia-container/src/test/scala/com/phylage/scaladia/InjectionTest.scala
+++ b/scaladia-container/src/test/scala/com/phylage/scaladia/InjectionTest.scala
@@ -1,7 +1,6 @@
 package com.phylage.scaladia
 
-import com.phylage.scaladia.InjectionTest.TEST301.EX_TestIF_301
-import com.phylage.scaladia.exception.{DIAutoInitializationException, InjectDefinitionException}
+import com.phylage.scaladia.exception.DIAutoInitializationException
 import com.phylage.scaladia.injector.Injector.@@
 import com.phylage.scaladia.injector.{AutoInject, AutoInjectCustomPriority, Injector, RecoveredInject}
 import com.phylage.scaladia.provider.{Lazy, Tag}
@@ -32,6 +31,7 @@ object InjectionTest {
     trait TestIF_3
 
     object TestIFImpl_3_RECOVER extends TestIF_3 with RecoveredInject[TestIF_3]
+
     object TestIFImpl_3_AUTO extends TestIF_3 with AutoInject[TestIF_3]
 
   }
@@ -41,7 +41,9 @@ object InjectionTest {
     trait TestIF_4
 
     object TestIFImpl_4_RECOVER extends TestIF_4 with RecoveredInject[TestIF_4]
+
     object TestIFImpl_4_CUSTOM extends AutoInjectCustomPriority[TestIF_4](1) with TestIF_4
+
   }
 
   object TEST5 {
@@ -49,7 +51,9 @@ object InjectionTest {
     trait TestIF_5
 
     object TestIFImpl_5_RECOVER extends TestIF_5 with RecoveredInject[TestIF_5]
+
     object TestIFImpl_5_CUSTOM extends AutoInjectCustomPriority[TestIF_5](0) with TestIF_5
+
   }
 
   object TEST6 {
@@ -57,7 +61,9 @@ object InjectionTest {
     trait TestIF_6
 
     object TestIFImpl_6_AUTO extends TestIF_6 with AutoInject[TestIF_6]
+
     object TestIFImpl_6_CUSTOM extends AutoInjectCustomPriority[TestIF_6](999) with TestIF_6
+
   }
 
   object TEST7 {
@@ -65,7 +71,9 @@ object InjectionTest {
     trait TestIF_7
 
     object TestIFImpl_7_AUTO extends TestIF_7 with AutoInject[TestIF_7]
+
     object TestIFImpl_7_CUSTOM extends AutoInjectCustomPriority[TestIF_7](1000) with TestIF_7
+
   }
 
   object TEST8 {
@@ -73,7 +81,9 @@ object InjectionTest {
     trait TestIF_8
 
     object TestIFImpl_8_AUTO extends TestIF_8 with AutoInject[TestIF_8]
+
     object TestIFImpl_8_CUSTOM extends AutoInjectCustomPriority[TestIF_8](1001) with TestIF_8
+
   }
 
   object TEST101 {
@@ -81,6 +91,7 @@ object InjectionTest {
     trait TestIF_101
 
     object TestIFImpl_101_AUTO extends TestIF_101 with AutoInject[TestIF_101]
+
   }
 
   object TEST102 {
@@ -88,6 +99,7 @@ object InjectionTest {
     trait TestIF_102
 
     object TestIFImpl_102_AUTO extends TestIF_102 with AutoInject[TestIF_102]
+
   }
 
   object TEST103 {
@@ -95,6 +107,7 @@ object InjectionTest {
     trait TestIF_103
 
     object TestIFImpl_103_AUTO extends TestIF_103 with AutoInject[TestIF_103]
+
   }
 
   object TEST104 {
@@ -102,6 +115,7 @@ object InjectionTest {
     trait TestIF_104
 
     object TestIFImpl_104_AUTO extends TestIF_104 with AutoInject[TestIF_104]
+
   }
 
   object TEST105 {
@@ -113,9 +127,13 @@ object InjectionTest {
     trait AccessorTest extends Injector {
       def get = inject[TestIF_105]
     }
+
     object AccessorA extends AccessorTest
+
     object AccessorB extends AccessorTest
+
     object AccessorC extends AccessorTest
+
   }
 
   object TEST106 {
@@ -127,15 +145,21 @@ object InjectionTest {
     trait AccessorTestA extends Injector {
       def get: Lazy[TestIF_106] = inject[TestIF_106]
     }
+
     trait AccessorTestB extends Injector {
       def get: Lazy[TestIF_106] = inject[TestIF_106]
     }
+
     trait AccessorTestC extends Injector {
       def get: Lazy[TestIF_106] = inject[TestIF_106]
     }
+
     object AccessorA extends AccessorTestA
+
     object AccessorB extends AccessorTestB
+
     object AccessorC extends AccessorTestC
+
   }
 
   object TEST107 {
@@ -143,6 +167,7 @@ object InjectionTest {
     trait TestIF_107
 
     object TestIFImpl_107_AUTO extends TestIF_107 with AutoInject[TestIF_107]
+
   }
 
   object TEST201 {
@@ -150,28 +175,37 @@ object InjectionTest {
     trait TestIF_201
 
     trait TestTagA
+
     trait TestTagB
+
     trait TestTagC
 
     object TestIFImpl_201_TAGNONE extends TestIF_201 with AutoInject[TestIF_201]
+
     object TestIFImpl_201_TAGA extends TestIF_201 with Tag[TestTagA] with AutoInject[TestIF_201 @@ TestTagA]
+
     object TestIFImpl_201_TAGB extends TestIF_201 with Tag[TestTagB] with AutoInject[TestIF_201 @@ TestTagB]
+
   }
 
   object TEST301 {
 
     trait TestIF_301
+
     trait EX_TestIF_301 extends TestIF_301
 
     object TestIFImpl_301_AUTO extends TestIF_301 with AutoInject[TestIF_301]
+
   }
 
   object TEST302 {
 
     trait TestIF_302
+
     trait EX_TestIF_302 extends TestIF_302
 
     object TestIFImpl_302_AUTO extends EX_TestIF_302 with AutoInject[TestIF_302]
+
   }
 
   object TEST303 {
@@ -181,37 +215,51 @@ object InjectionTest {
         override val inst: T = t
       }
     }
+
     trait Wrap_303[+T <: TestIF] {
       val inst: T
     }
+
     trait TestIF
+
     trait TestIF_303_A extends TestIF
+
     trait TestIF_303_B extends TestIF
+
   }
 
   object TEST304 {
+
     trait TestIF_304_A
+
     trait TestIF_304_B
+
   }
 
   object TEST305 {
 
     import scala.reflect.runtime.universe.WeakTypeTag
-    abstract class Wrap_305[+T <: TestIF: WeakTypeTag] {
+
+    abstract class Wrap_305[+T <: TestIF : WeakTypeTag] {
       val inst: T
     }
+
     trait TestIF
 
     trait TestIF_305_A extends TestIF
+
     object TestIF_305_A_WRAP extends Wrap_305[TestIF_305_A] with AutoInject[Wrap_305[TestIF_305_A]] {
       val inst: TestIF_305_A = new TestIF_305_A {}
     }
 
     trait TestIF_305_B extends TestIF
+
     object TestIF_305_B_WRAP extends Wrap_305[TestIF_305_B] with AutoInject[Wrap_305[TestIF_305_B]] {
       val inst: TestIF_305_B = new TestIF_305_B {}
     }
+
   }
+
 }
 
 class InjectionTest extends AsyncWordSpec with Matchers with DiagrammedAssertions with Injector {
@@ -397,15 +445,15 @@ class InjectionTest extends AsyncWordSpec with Matchers with DiagrammedAssertion
     "type erase" in {
       import TEST303._
 
-      val r_A = Wrap(new TestIF_303_A{})
+      val r_A = Wrap(new TestIF_303_A {})
 
-      val r_B = Wrap(new TestIF_303_B{})
+      val r_B = Wrap(new TestIF_303_B {})
 
       overwrite[Wrap_303[TestIF_303_A]](r_A)
       overwrite[Wrap_303[TestIF_303_B]](r_B)
 
       import scala.reflect.runtime.universe._
-      def get[T <: TestIF: WeakTypeTag]: Lazy[Wrap_303[T]] = inject[Wrap_303[T]]
+      def get[T <: TestIF : WeakTypeTag]: Lazy[Wrap_303[T]] = inject[Wrap_303[T]]
 
       get[TestIF_303_A].provide shouldBe r_A
       get[TestIF_303_B].provide shouldBe r_B
@@ -415,15 +463,15 @@ class InjectionTest extends AsyncWordSpec with Matchers with DiagrammedAssertion
       import TEST304._
 
       val r_A = Seq(
-        new TestIF_304_A{},
-        new TestIF_304_A{},
-        new TestIF_304_A{}
+        new TestIF_304_A {},
+        new TestIF_304_A {},
+        new TestIF_304_A {}
       )
 
       val r_B = Seq(
-        new TestIF_304_B{},
-        new TestIF_304_B{},
-        new TestIF_304_B{}
+        new TestIF_304_B {},
+        new TestIF_304_B {},
+        new TestIF_304_B {}
       )
 
       overwrite[Seq[TestIF_304_A]](r_A)
@@ -433,14 +481,14 @@ class InjectionTest extends AsyncWordSpec with Matchers with DiagrammedAssertion
       inject[Seq[TestIF_304_B]].provide shouldBe r_B
     }
 
-//    "type erase with Auto" in {
-//      import TEST305._
-//
-//      import scala.reflect.runtime.universe._
-//      def get[T <: TestIF: WeakTypeTag]: Lazy[Wrap_305[T]] = inject[Wrap_305[T]]
-//
-//      get[TestIF_305_A].provide shouldBe TestIF_305_A_WRAP
-//      get[TestIF_305_B].provide shouldBe TestIF_305_B_WRAP
-//    }
+    "type erase with Auto" in {
+      import TEST305._
+
+      import scala.reflect.runtime.universe._
+      def get[T <: TestIF : WeakTypeTag]: Lazy[Wrap_305[T]] = inject[Wrap_305[T]]
+
+      get[TestIF_305_A].provide shouldBe TestIF_305_A_WRAP
+      get[TestIF_305_B].provide shouldBe TestIF_305_B_WRAP
+    }
   }
 }

--- a/scaladia-container/version.sbt
+++ b/scaladia-container/version.sbt
@@ -1,1 +1,1 @@
-version in ThisProject := "2.1.1"
+version in ThisProject := "2.1.2"

--- a/scaladia-http/README.md
+++ b/scaladia-http/README.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```
-libraryDependencies += "com.phylage" %% "scaladia-http" % "0.2.0"
+libraryDependencies += "com.phylage" %% "scaladia-http" % "0.2.2"
 ````
 
 ## Examples

--- a/scaladia-http/version.sbt
+++ b/scaladia-http/version.sbt
@@ -1,1 +1,1 @@
-version in ThisProject := "0.2.1"
+version in ThisProject := "0.2.2"

--- a/scaladia-lang/version.sbt
+++ b/scaladia-lang/version.sbt
@@ -1,1 +1,1 @@
-version in ThisProject := "1.1.1"
+version in ThisProject := "1.1.2"

--- a/scaladia-macro/src/main/scala/com/phylage/scaladia/injector/AutoInjectable.scala
+++ b/scaladia-macro/src/main/scala/com/phylage/scaladia/injector/AutoInjectable.scala
@@ -3,4 +3,4 @@ package com.phylage.scaladia.injector
 /**
   * This is subject to automatic loading by scaladia.
   */
-trait AutoInjectable
+trait AutoInjectable[T]

--- a/scaladia-macro/src/main/scala/com/phylage/scaladia/injector/InjectionPool.scala
+++ b/scaladia-macro/src/main/scala/com/phylage/scaladia/injector/InjectionPool.scala
@@ -1,0 +1,29 @@
+package com.phylage.scaladia.injector
+
+import com.phylage.scaladia.injector.scope.InjectableScope
+
+import scala.reflect.runtime.universe._
+
+trait InjectionPool {
+  type InjectionApplyment[T] = () => InjectableScope[T]
+
+  /**
+    * Pool Injectable subtypes for automatic loading.
+    * The timing to be initialized is when the related
+    * component is initialized or when it is called by inject.
+    *
+    * @param value injection object
+    * @tparam T injection type
+    * @return
+    */
+  def pool[T](value: InjectionType[T]): Unit
+
+  /**
+    * Get a list of injection-enabled declarations of any type
+    *
+    * @param wtt weak type tag.
+    * @tparam T Type you are trying to get
+    * @return
+    */
+  def collect[T](implicit wtt: WeakTypeTag[T]): Vector[InjectionApplyment[T]]
+}

--- a/scaladia-macro/src/main/scala/com/phylage/scaladia/injector/InjectionType.scala
+++ b/scaladia-macro/src/main/scala/com/phylage/scaladia/injector/InjectionType.scala
@@ -1,0 +1,10 @@
+package com.phylage.scaladia.injector
+
+import com.phylage.scaladia.injector.scope.InjectableScope
+
+import scala.reflect.runtime.universe._
+
+object InjectionType {
+  def apply[T](applyment: () => InjectableScope[T])(implicit wtt: WeakTypeTag[T]): InjectionType[T] = InjectionType(wtt, applyment)
+}
+case class InjectionType[T](wtt: WeakTypeTag[T], applyment: () => InjectableScope[T])

--- a/scaladia-macro/src/main/scala/com/phylage/scaladia/internal/AutoDIExtractor.scala
+++ b/scaladia-macro/src/main/scala/com/phylage/scaladia/internal/AutoDIExtractor.scala
@@ -67,7 +67,7 @@ class AutoDIExtractor[C <: blackbox.Context](val c: C) {
     config.map(_.value)
   }
 
-  private[this] val autoDITag = weakTypeOf[AutoInjectable]
+  private[this] val autoDITag = weakTypeOf[AutoInjectable[_]]
 
 
   def run[T: C#WeakTypeTag](): Vector[Symbol] = {

--- a/scaladia-macro/src/main/scala/com/phylage/scaladia/internal/LazyInitializer.scala
+++ b/scaladia-macro/src/main/scala/com/phylage/scaladia/internal/LazyInitializer.scala
@@ -1,6 +1,7 @@
 package com.phylage.scaladia.internal
 
 import com.phylage.scaladia.container.Container
+import com.phylage.scaladia.injector.InjectionPool
 import com.phylage.scaladia.provider.Lazy
 
 import scala.reflect.macros.blackbox
@@ -9,12 +10,12 @@ class LazyInitializer[C <: blackbox.Context](val c: C) {
 
   import c.universe._
 
-  def lazyInit[T: C#WeakTypeTag](fire: c.Expr[Unit], ctn: Tree, access: c.Tree): Expr[Lazy[T]] = {
+  def lazyInit[T: C#WeakTypeTag](fire: c.Expr[Unit], ctn: Tree, ip: Tree, access: c.Tree): Expr[Lazy[T]] = {
     c.Expr[Lazy[T]](
       q"""
          new com.phylage.scaladia.provider.Lazy[${weakTypeOf[T]}] {
            lazy val provide: ${weakTypeOf[T]} = try {
-             ${injection[T](ctn, fire, access)}
+             ${injection[T](ctn, ip, fire, access)}
            } catch {
              case e: java.lang.Throwable =>
                throw new com.phylage.scaladia.exception.DIAutoInitializationException(${weakTypeOf[T].typeSymbol.fullName} + " or its internal initialize failed.", e)
@@ -24,11 +25,11 @@ class LazyInitializer[C <: blackbox.Context](val c: C) {
     )
   }
 
-  def diligentInit[T: C#WeakTypeTag](fire: c.Expr[Unit], ctn: Tree, access: c.Tree): Expr[T] = {
-    injection[T](ctn, fire, access)
+  def diligentInit[T: C#WeakTypeTag](fire: c.Expr[Unit], ctn: Tree, ip: Tree, access: c.Tree): Expr[T] = {
+    injection[T](ctn, ip, fire, access)
   }
 
-  def injection[T: C#WeakTypeTag](ctn: Tree, fire: c.Expr[Unit], access: c.Tree): Expr[T] = {
+  def injection[T: C#WeakTypeTag](ctn: Tree, ip: Tree, fire: c.Expr[Unit], access: c.Tree): Expr[T] = {
     val tag = weakTypeOf[T]
 
     val mayBeInjection = c.Expr[Option[T]](
@@ -40,7 +41,9 @@ class LazyInitializer[C <: blackbox.Context](val c: C) {
     c.Expr[T] {
       q"""
        $mayBeInjection orElse {
+         val _pool = ${c.Expr[InjectionPool](ip)}
          $fire
+         _pool.collect[$tag].map(_.apply())
          $mayBeInjection
        } getOrElse {
          throw new com.phylage.scaladia.exception.InjectDefinitionException(s"Cannot found " + ${tag.typeSymbol.fullName} + " implementation.")

--- a/scaladia-macro/version.sbt
+++ b/scaladia-macro/version.sbt
@@ -1,1 +1,1 @@
-version in ThisProject := "1.1.1"
+version in ThisProject := "1.1.2"


### PR DESCRIPTION
Delayed initialization at runtime.

- Before
> At the first access to Lazy [T], flush all macro-expanded injection sets.

=> When you inject a class that needs to refer to the Runtime classpath, it may become uncompilable

- After
> Generate syntax tree to initialize injectable set by macro expansion.
> During Lazy.provide, if the container does not have the required dependencies, then always update the Injectable Set and flush some Injectable Sets with the required type.