### PR TITLE
v2.3.0 Added a function to repool auto-insertable objects that exist in the current classpath.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,8 @@ import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations._
 
 lazy val buildTargetVersion = Seq("2.11.12", "2.12.8", "2.13.0")
 
+
+
 lazy val assemblySettings = Seq(
   scalaVersion := GLOBAL_SCALA_VERSION,
   publishTo := Some(
@@ -46,7 +48,10 @@ lazy val root = project.in(file("."))
     scaladiaMacro,
     scaladiaContainer,
     scaladiaLang,
-    scaladiaHttp
+    scaladiaHttp,
+    root_interfaces,
+    interfaces_impl,
+    call_interfaces
   ).settings(
   publishLocal in ThisProject := {},
   publishArtifact in ThisProject := false,
@@ -114,5 +119,26 @@ lazy val scaladiaHttp = (project in file("scaladia-http"))
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.9"
     )
   ).enablePlugins(JavaAppPackaging)
+
+lazy val root_interfaces = (project in file("test-across-module/root_interfaces"))
+  .dependsOn(scaladiaHttp)
+  .settings(commonDependencySettings, assemblySettings)
+  .settings(
+    releaseProcess := Nil
+  )
+
+lazy val interfaces_impl = (project in file("test-across-module/interfaces_impl"))
+  .dependsOn(root_interfaces)
+  .settings(commonDependencySettings, assemblySettings)
+  .settings(
+    releaseProcess := Nil
+  )
+
+lazy val call_interfaces = (project in file("test-across-module/call_interfaces"))
+  .dependsOn(interfaces_impl)
+  .settings(commonDependencySettings, assemblySettings)
+  .settings(
+    releaseProcess := Nil
+  )
 
 val GLOBAL_SCALA_VERSION = "2.13.0"

--- a/scaladia-container/README.md
+++ b/scaladia-container/README.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```
-libraryDependencies += "com.phylage" %% "scaladia-container" % "2.1.2"
+libraryDependencies += "com.phylage" %% "scaladia-container" % "2.3.0"
 ````
 
 ### Simplest Injection

--- a/scaladia-container/src/main/scala/com/phylage/scaladia/injector/RefreshInjection.scala
+++ b/scaladia-container/src/main/scala/com/phylage/scaladia/injector/RefreshInjection.scala
@@ -1,0 +1,36 @@
+package com.phylage.scaladia.injector
+
+import com.phylage.scaladia.internal.Macro
+
+/**
+  * Used to repool auto-injectable objects present in the current classpath.
+  *
+  * Basic injection needs to be executed in the module to be started first.
+  * The declaration injected in the library has already completed macro expansion.
+  *
+  * That is, when a third-party object accessed without injection tries to inject
+  * someone for the first time, higher priority objects in the current classpath may be ignored.
+  *
+  * At that time, by inheriting RefreshInjection at a higher level, AutoInjectable in the class path will be pooled again.
+  */
+trait RefreshInjection extends Injector {
+  /**
+    * Instantiates injectable objects and updates the pool with the current classpath.
+    * For example, if this is {{{inject[Runner].execute}}}, you do not need reify.
+    *
+    * {{{
+    * object Main extends App with RefreshInjection {
+    *   reify {
+    *     // Runner is an external dependency module.
+    *     // The call to inject[X] internally, the implementation class of X is in the first-party module.
+    *     println(Runner.execute)
+    *   }
+    * }
+    * }}}
+    *
+    * @param fun any function
+    * @tparam T result type
+    * @return
+    */
+  def reify[T](fun: T)(implicit ip: InjectionPool): T = macro Macro.reifyClasspathInjectables[T]
+}

--- a/scaladia-container/version.sbt
+++ b/scaladia-container/version.sbt
@@ -1,1 +1,1 @@
-version in ThisProject := "2.2.0"
+version in ThisProject := "2.3.0-SNAPSHOT"

--- a/scaladia-http/README.md
+++ b/scaladia-http/README.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```
-libraryDependencies += "com.phylage" %% "scaladia-http" % "0.2.2"
+libraryDependencies += "com.phylage" %% "scaladia-http" % "0.4.0"
 ````
 
 ## Examples

--- a/scaladia-http/version.sbt
+++ b/scaladia-http/version.sbt
@@ -1,1 +1,1 @@
-version in ThisProject := "0.3.0"
+version in ThisProject := "0.4.0"

--- a/scaladia-lang/version.sbt
+++ b/scaladia-lang/version.sbt
@@ -1,1 +1,1 @@
-version in ThisProject := "1.2.0"
+version in ThisProject := "1.3.0"

--- a/scaladia-macro/src/main/scala/com/phylage/scaladia/internal/Macro.scala
+++ b/scaladia-macro/src/main/scala/com/phylage/scaladia/internal/Macro.scala
@@ -1,7 +1,5 @@
 package com.phylage.scaladia.internal
 
-import com.phylage.scaladia.container.Container
-import com.phylage.scaladia.injector.InjectionType
 import com.phylage.scaladia.provider.Lazy
 
 import scala.reflect.macros.blackbox
@@ -9,11 +7,8 @@ import scala.reflect.macros.blackbox
 
 object Macro {
 
-  def scrapeInjectionTypes(c: blackbox.Context)(): c.Expr[Iterable[InjectionType[_]]] = {
-    import c.universe._
-    new InjectionCompound[c.type](c).build(
-      AutoDIExtractor.collectApplyTarget[c.type, Container](c)(weakTypeTag[Container])
-    )
+  def reifyClasspathInjectables[T: c.WeakTypeTag](c: blackbox.Context)(fun: c.Tree)(ip: c.Tree): c.Expr[T] = {
+    new LazyInitializer[c.type](c).classpathRepooling[T](fun, ip)
   }
 
   def lazyInject[T: c.WeakTypeTag](c: blackbox.Context)(ctn: c.Tree, ip: c.Tree, access: c.Tree): c.Expr[Lazy[T]] = {

--- a/scaladia-macro/version.sbt
+++ b/scaladia-macro/version.sbt
@@ -1,1 +1,1 @@
-version in ThisProject := "1.2.0"
+version in ThisProject := "1.3.0"

--- a/test-across-module/call_interfaces/src/main/scala/com/phylage/scaladia/test/Executor.scala
+++ b/test-across-module/call_interfaces/src/main/scala/com/phylage/scaladia/test/Executor.scala
@@ -1,0 +1,15 @@
+package com.phylage.scaladia.test
+
+import com.phylage.scaladia.injector.{Injector, RefreshInjection}
+import com.phylage.scaladia.test.RootIF.Runner
+
+object Executor extends RefreshInjection {
+
+  object PureExecution {
+    def exec: String = Runner.run
+  }
+
+  object InjectionExecution extends Injector {
+    def exec: String = inject[Runner].run
+  }
+}

--- a/test-across-module/call_interfaces/src/test/scala/com/phylage/scaladia/test/ModuleAcrossInjectionTest.scala
+++ b/test-across-module/call_interfaces/src/test/scala/com/phylage/scaladia/test/ModuleAcrossInjectionTest.scala
@@ -1,0 +1,30 @@
+package com.phylage.scaladia.test
+
+import com.phylage.scaladia.injector.RefreshInjection
+import com.phylage.scaladia.test.Executor.{InjectionExecution, PureExecution}
+import org.scalatest.{AsyncWordSpec, DiagrammedAssertions, Matchers}
+
+import scala.util.{Failure, Success, Try}
+
+class ModuleAcrossInjectionTest extends AsyncWordSpec with Matchers with DiagrammedAssertions with RefreshInjection {
+  "Module across injection test" should {
+    "pure call" in {
+      Try {
+        PureExecution.exec shouldBe ConfImpl.value
+      } match {
+        case Success(_) => fail("It can not be solved by the internal call which does not pass injection")
+        case Failure(e) => e.getMessage shouldBe "com.phylage.scaladia.test.Conf or its internal initialize failed."
+      }
+    }
+
+    "pure call with reify" in {
+      reify {
+        PureExecution.exec shouldBe ConfImpl.value
+      }
+    }
+
+    "call after injection" in {
+      InjectionExecution.exec shouldBe ConfImpl.value
+    }
+  }
+}

--- a/test-across-module/interfaces_impl/src/main/scala/com/phylage/scaladia/test/ConfImpl.scala
+++ b/test-across-module/interfaces_impl/src/main/scala/com/phylage/scaladia/test/ConfImpl.scala
@@ -1,0 +1,7 @@
+package com.phylage.scaladia.test
+
+import com.phylage.scaladia.injector.AutoInject
+
+object ConfImpl extends Conf with AutoInject[Conf] {
+  val value: String = "ConfImpl"
+}

--- a/test-across-module/root_interfaces/src/main/scala/com/phylage/scaladia/test/RootIF.scala
+++ b/test-across-module/root_interfaces/src/main/scala/com/phylage/scaladia/test/RootIF.scala
@@ -1,0 +1,14 @@
+package com.phylage.scaladia.test
+
+import com.phylage.scaladia.injector.{AutoInject, Injector}
+
+object RootIF extends Injector {
+
+  trait Runner {
+    def run: String = inject[Conf].value
+  }
+  object Runner extends Runner with AutoInject[Runner]
+}
+trait Conf {
+  val value: String
+}


### PR DESCRIPTION
Added a function to repool auto-insertable objects that exist in the current classpath.

Basic injection needs to be executed in the module to be started first.
The declaration injected in the library has already completed macro expansion.

That is, when a third-party object accessed without injection tries to inject
someone for the first time, higher priority objects in the current classpath may be ignored.

At that time, by inheriting RefreshInjection at a higher level, AutoInjectable in the class path will be pooled again.