### PR TITLE
v2.4.0 Implementation of shading

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,10 +45,10 @@ lazy val commonDependencySettings = Seq(
 
 lazy val root = project.in(file("."))
   .aggregate(
-    scaladiaMacro,
-    scaladiaContainer,
-    scaladiaLang,
-    scaladiaHttp,
+    `macro`,
+    container,
+    lang,
+    http,
     root_interfaces,
     interfaces_impl,
     call_interfaces
@@ -59,7 +59,7 @@ lazy val root = project.in(file("."))
   crossScalaVersions := buildTargetVersion
 )
 
-lazy val scaladiaMacro = (project in file("scaladia-macro"))
+lazy val `macro` = (project in file("scaladia-macro"))
   .settings(assemblySettings)
   .settings(commonDependencySettings)
   .settings(
@@ -75,10 +75,10 @@ lazy val scaladiaMacro = (project in file("scaladia-macro"))
     scalacOptions += "-language:experimental.macros"
   )
 
-lazy val scaladiaContainer = (project in file("scaladia-container"))
+lazy val container = (project in file("scaladia-container"))
   .settings(assemblySettings)
   .settings(commonDependencySettings)
-  .dependsOn(scaladiaMacro)
+  .dependsOn(`macro`)
   .settings(
     name := "scaladia-container",
     description := "Lightweight DI container for Scala.",
@@ -95,17 +95,17 @@ lazy val scaladiaContainer = (project in file("scaladia-container"))
     unmanagedClasspath in Compile ++= (unmanagedResources in Compile).value
   ).enablePlugins(JavaAppPackaging)
 
-lazy val scaladiaLang = (project in file("scaladia-lang"))
+lazy val lang = (project in file("scaladia-lang"))
   .settings(assemblySettings)
   .settings(commonDependencySettings)
-  .dependsOn(scaladiaContainer)
+  .dependsOn(container)
   .settings(
     name := "scaladia-lang",
     parallelExecution in Test := true
   ).enablePlugins(JavaAppPackaging)
 
-lazy val scaladiaHttp = (project in file("scaladia-http"))
-  .dependsOn(scaladiaLang)
+lazy val http = (project in file("scaladia-http"))
+  .dependsOn(lang)
   .settings(assemblySettings)
   .settings(commonDependencySettings)
   .settings(
@@ -120,8 +120,8 @@ lazy val scaladiaHttp = (project in file("scaladia-http"))
     )
   ).enablePlugins(JavaAppPackaging)
 
-lazy val scaladiaTest = (project in file("scaladia-test"))
-  .dependsOn(scaladiaHttp)
+lazy val `test` = (project in file("scaladia-test"))
+  .dependsOn(http)
   .settings(assemblySettings)
   .settings(commonDependencySettings)
   .settings(
@@ -133,7 +133,7 @@ lazy val scaladiaTest = (project in file("scaladia-test"))
   ).enablePlugins(JavaAppPackaging)
 
 lazy val root_interfaces = (project in file("test-across-module/root_interfaces"))
-  .dependsOn(scaladiaHttp)
+  .dependsOn(http)
   .settings(commonDependencySettings, assemblySettings)
   .settings(
     releaseProcess := Nil

--- a/scaladia-container/src/main/scala/com/phylage/scaladia/container/InjectionPool.scala
+++ b/scaladia-container/src/main/scala/com/phylage/scaladia/container/InjectionPool.scala
@@ -1,7 +1,6 @@
 package com.phylage.scaladia.container
 
 import com.phylage.scaladia.injector.InjectionType
-import com.typesafe.scalalogging.Logger
 
 import scala.collection.mutable.ListBuffer
 import scala.reflect.runtime.universe._
@@ -32,10 +31,6 @@ object InjectionPool extends com.phylage.scaladia.injector.InjectionPool {
     */
   def collect[T](implicit wtt: WeakTypeTag[T]): Vector[InjectionApplyment[T]] = synchronized {
     {
-      // println(s"TARGET : ${wtt.tpe.typeSymbol.fullName}")
-      // buffer.map(_.name).foreach(println)
-      // println()
-
       buffer.collect {
         case x if wtt.tpe.=:=(x.wtt.tpe) => x
       } map(_.applyment)

--- a/scaladia-container/src/main/scala/com/phylage/scaladia/container/InjectionPool.scala
+++ b/scaladia-container/src/main/scala/com/phylage/scaladia/container/InjectionPool.scala
@@ -32,6 +32,10 @@ object InjectionPool extends com.phylage.scaladia.injector.InjectionPool {
     */
   def collect[T](implicit wtt: WeakTypeTag[T]): Vector[InjectionApplyment[T]] = synchronized {
     {
+      // println(s"TARGET : ${wtt.tpe.typeSymbol.fullName}")
+      // buffer.map(_.name).foreach(println)
+      // println()
+
       buffer.collect {
         case x if wtt.tpe.=:=(x.wtt.tpe) => x
       } map(_.applyment)

--- a/scaladia-container/src/main/scala/com/phylage/scaladia/container/indexer/BroadSenseIndexer.scala
+++ b/scaladia-container/src/main/scala/com/phylage/scaladia/container/indexer/BroadSenseIndexer.scala
@@ -5,13 +5,16 @@ import com.phylage.scaladia.injector.scope.{AcceptedFromInstanceScope, AcceptedF
 
 import scala.reflect.{ClassTag, classTag}
 
-class BroadSenseIndexer[T](scope: OpenScope[T], cnt: Container) extends AbstractIndexer[T] {
+class BroadSenseIndexer[T](scope: OpenScope[T], cnt: Vector[Container]) extends AbstractIndexer[T] {
   /**
     * Create a new object in the injection container.
     *
     * @return
     */
-  override def indexing(): InjectableScope[T] = cnt.cache(scope)
+  override def indexing(): InjectableScope[T] = {
+    cnt.foreach(_.cache(scope))
+    scope
+  }
 
   /**
     * Register a new authorization instance with this indexer.

--- a/scaladia-container/src/main/scala/com/phylage/scaladia/container/indexer/NarrowInstanceIndexer.scala
+++ b/scaladia-container/src/main/scala/com/phylage/scaladia/container/indexer/NarrowInstanceIndexer.scala
@@ -5,13 +5,16 @@ import com.phylage.scaladia.injector.scope.{AcceptedFromInstanceScope, Injectabl
 
 import scala.reflect.ClassTag
 
-class NarrowInstanceIndexer[T](scope: AcceptedFromInstanceScope[T], cnt: Container) extends AbstractIndexer[T] {
+class NarrowInstanceIndexer[T](scope: AcceptedFromInstanceScope[T], cnt: Vector[Container]) extends AbstractIndexer[T] {
   /**
     * Create a new object in the injection container.
     *
     * @return
     */
-  override def indexing(): InjectableScope[T] = cnt.cache(scope)
+  override def indexing(): InjectableScope[T] = {
+    cnt.foreach(_.cache(scope))
+    scope
+  }
 
   /**
     * Create a new authorization class for this indexer.

--- a/scaladia-container/src/main/scala/com/phylage/scaladia/container/indexer/NarrowTypeIndexer.scala
+++ b/scaladia-container/src/main/scala/com/phylage/scaladia/container/indexer/NarrowTypeIndexer.scala
@@ -5,13 +5,16 @@ import com.phylage.scaladia.injector.scope.{AcceptedFromTypeScope, InjectableSco
 
 import scala.reflect.{ClassTag, classTag}
 
-class NarrowTypeIndexer[T](scope: AcceptedFromTypeScope[T], cnt: Container) extends AbstractIndexer[T] {
+class NarrowTypeIndexer[T](scope: AcceptedFromTypeScope[T], cnt: Vector[Container]) extends AbstractIndexer[T] {
   /**
     * Create a new object in the injection container.
     *
     * @return
     */
-  override def indexing(): InjectableScope[T] = cnt.cache(scope)
+  override def indexing(): InjectableScope[T] = {
+    cnt.foreach(_.cache(scope))
+    scope
+  }
 
   /**
     * Create a new authorization class for this indexer.

--- a/scaladia-container/src/main/scala/com/phylage/scaladia/container/package.scala
+++ b/scaladia-container/src/main/scala/com/phylage/scaladia/container/package.scala
@@ -34,6 +34,7 @@ package object container {
       * @return
       */
     def find[T: WeakTypeTag](requestFrom: Accessor[_]): Option[T] = synchronized {
+      // println(s"Shadind : ${shaded}")
       buffer.filter(_.accepted[T](requestFrom))
         .sortBy(_.priority)
         .lastOption

--- a/scaladia-container/src/main/scala/com/phylage/scaladia/injector/AutoInject.scala
+++ b/scaladia-container/src/main/scala/com/phylage/scaladia/injector/AutoInject.scala
@@ -1,6 +1,6 @@
 package com.phylage.scaladia.injector
 
-import com.phylage.scaladia.container.ContainerStore
+import com.phylage.scaladia.container.Container
 import com.phylage.scaladia.injector.scope.InjectableScope
 
 /**
@@ -18,8 +18,8 @@ trait AutoInject[T] extends AutoInjectable[T] with Injector {
 
   import scala.reflect.runtime.universe._
 
-  def flush(implicit wtt: WeakTypeTag[T]): InjectableScope[T] = {
-    implicitly[ContainerStore].ctn.createIndexer[T](
+  def flush(c: Container)(implicit wtt: WeakTypeTag[T]): InjectableScope[T] = {
+    c.createIndexer[T](
       me,
       injectionPriority
     )(implicitly[WeakTypeTag[T]]).indexing()

--- a/scaladia-container/src/main/scala/com/phylage/scaladia/injector/AutoInjectCustomPriority.scala
+++ b/scaladia-container/src/main/scala/com/phylage/scaladia/injector/AutoInjectCustomPriority.scala
@@ -4,6 +4,6 @@ package com.phylage.scaladia.injector
   * Inject automatically by specifying priority
   * @tparam T Type to register
   */
-class AutoInjectCustomPriority[T](private[scaladia] override val injectionPriority: Int) extends AutoInject[T] with Injector { me: T =>
+class AutoInjectCustomPriority[T](private[scaladia] override val injectionPriority: Int) extends AutoInject[T] { me: T =>
 
 }

--- a/scaladia-container/src/main/scala/com/phylage/scaladia/injector/ContainerAccessible.scala
+++ b/scaladia-container/src/main/scala/com/phylage/scaladia/injector/ContainerAccessible.scala
@@ -23,13 +23,13 @@ private[scaladia] trait ContainerAccessible[C <: Container] {
     * @param priority Injection priority.
     * @tparam T new dependency type
     */
-  def overwrite[T: WeakTypeTag](x: T, priority: Int = 1100)(implicit ctn: C): Unit = ctn.createIndexer(x, priority).indexing()
+  def overwrite[T: WeakTypeTag](x: T, priority: Int = 1100)(implicit ctn: C): Unit = ctn.createIndexer(x, priority, Vector.empty).indexing()
 
   /**
     * Create a container shade.
     *
-    * @param ctx
-    * @tparam T
+    * @param ctx Shaded container function.
+    * @tparam T Result type
     * @return
     */
   def shade[T](ctx: LocalizedContainer => T): T = new ImplicitContainerInheritation(ctx)(_cntMutation.shading)
@@ -65,7 +65,9 @@ private[scaladia] trait ContainerAccessible[C <: Container] {
     * @tparam X Variable type
     * @return
     */
-  implicit def _implicitProviding[X](variable: Lazy[X]): X = variable.provide
+  implicit def _implicitProviding[X](variable: Lazy[X]): X = {
+    variable._provide
+  }
 
   /**
     * This refers to itself
@@ -75,7 +77,7 @@ private[scaladia] trait ContainerAccessible[C <: Container] {
   protected implicit def _someoneNeeds: Accessor[_] = Accessor(me)
 
 
-  implicit def _cntMutation: C
+  implicit var _cntMutation: C
 
   /**
     * Implicitly injection pool

--- a/scaladia-container/src/main/scala/com/phylage/scaladia/injector/ContainerAccessible.scala
+++ b/scaladia-container/src/main/scala/com/phylage/scaladia/injector/ContainerAccessible.scala
@@ -1,5 +1,6 @@
 package com.phylage.scaladia.injector
 
+import com.phylage.scaladia.Types.LocalizedContainer
 import com.phylage.scaladia.container._
 import com.phylage.scaladia.container.indexer.Indexer
 import com.phylage.scaladia.internal.Macro
@@ -31,7 +32,7 @@ private[scaladia] trait ContainerAccessible[C <: Container] {
     * @tparam T
     * @return
     */
-  // def shade[T](ctx: LocalizedContainer => T): T = new ImplicitContainerInheritation(ctx)
+  def shade[T](ctx: LocalizedContainer => T): T = new ImplicitContainerInheritation(ctx)(_cntMutation.shading)
 
   /**
     * Gets an indexer for registering new dependencies.
@@ -64,17 +65,17 @@ private[scaladia] trait ContainerAccessible[C <: Container] {
     * @tparam X Variable type
     * @return
     */
-  implicit def implicitProviding[X](variable: Lazy[X]): X = variable.provide
+  implicit def _implicitProviding[X](variable: Lazy[X]): X = variable.provide
 
   /**
     * This refers to itself
     *
     * @return
     */
-  protected implicit def someoneNeeds: Accessor[_] = Accessor(me)
+  protected implicit def _someoneNeeds: Accessor[_] = Accessor(me)
 
 
-  implicit var _cntMutation: C
+  implicit def _cntMutation: C
 
   /**
     * Implicitly injection pool

--- a/scaladia-container/src/main/scala/com/phylage/scaladia/injector/Injector.scala
+++ b/scaladia-container/src/main/scala/com/phylage/scaladia/injector/Injector.scala
@@ -3,5 +3,5 @@ package com.phylage.scaladia.injector
 import com.phylage.scaladia.container.{Container, ContainerStore}
 
 trait Injector extends ContainerAccessible[Container] {
-  implicit var _cntMutation: Container = implicitly[ContainerStore].ctn
+  implicit def _cntMutation: Container = implicitly[ContainerStore].ctn
 }

--- a/scaladia-container/src/main/scala/com/phylage/scaladia/injector/Injector.scala
+++ b/scaladia-container/src/main/scala/com/phylage/scaladia/injector/Injector.scala
@@ -3,5 +3,5 @@ package com.phylage.scaladia.injector
 import com.phylage.scaladia.container.{Container, ContainerStore}
 
 trait Injector extends ContainerAccessible[Container] {
-  implicit def _cntMutation: Container = implicitly[ContainerStore].ctn
+  implicit var _cntMutation: Container = implicitly[ContainerStore].ctn
 }

--- a/scaladia-container/src/main/scala/com/phylage/scaladia/injector/package.scala
+++ b/scaladia-container/src/main/scala/com/phylage/scaladia/injector/package.scala
@@ -7,19 +7,18 @@ package object injector {
 
   private[scaladia] implicit object IndirectContainerStore extends ContainerStore {
     lazy val ctn: Container = initContainer
+    override val ijp: InjectionPool = InjectionPool
 
     def initContainer: Container = StandardContainer()
-
-    override val ijp: InjectionPool = InjectionPool
   }
 
   import scala.language.implicitConversions
+
   implicit def _containerInheritance[T](x: ImplicitContainerInheritation[T]): T = x.fx(x._cntMutation)
 
-  class ImplicitContainerInheritation[T](val fx: LocalizedContainer => T) extends ContainerAccessible[LocalizedContainer] {
+  class ImplicitContainerInheritation[T](val fx: LocalizedContainer => T)(c: LocalizedContainer) extends ContainerAccessible[LocalizedContainer] {
     it =>
-    implicit var _cntMutation: LocalizedContainer = implicitly[ContainerStore].ctn.shading
-
+    implicit def _cntMutation: LocalizedContainer = c
     // override def shade[I](ctx: LocalizedContainer => I): I = throw new InjectDefinitionException("Recursive calls to shade() are prohibited.")
   }
 

--- a/scaladia-container/src/main/scala/com/phylage/scaladia/injector/package.scala
+++ b/scaladia-container/src/main/scala/com/phylage/scaladia/injector/package.scala
@@ -18,7 +18,7 @@ package object injector {
 
   class ImplicitContainerInheritation[T](val fx: LocalizedContainer => T)(c: LocalizedContainer) extends ContainerAccessible[LocalizedContainer] {
     it =>
-    implicit def _cntMutation: LocalizedContainer = c
+    implicit var _cntMutation: LocalizedContainer = c
     // override def shade[I](ctx: LocalizedContainer => I): I = throw new InjectDefinitionException("Recursive calls to shade() are prohibited.")
   }
 

--- a/scaladia-container/src/test/scala/com/phylage/scaladia/InjectionTest.scala
+++ b/scaladia-container/src/test/scala/com/phylage/scaladia/InjectionTest.scala
@@ -176,6 +176,8 @@ object InjectionTest {
   object TEST108 {
 
     trait A108
+    trait A108_TRAIT
+    class A180_CLASS extends A108_TRAIT with AutoInject[A108_TRAIT]
 
     object A108_REPLACE extends A108
 
@@ -423,16 +425,16 @@ class InjectionTest extends AsyncWordSpec with Matchers with DiagrammedAssertion
       inspection shouldBe TestIFImpl_107_AUTO
     }
 
-//    "using pattern" in {
-//      import TEST108._
-//
-//      shade[Assertion] { implicit c =>
-//        overwrite[A108](A108_REPLACE)
-//        inject[C108].provide.b.a.provide shouldBe A108_REPLACE
-//      }
-//
-//      inject[C108].provide.b.a.provide shouldBe A108
-//    }
+    "using pattern" in {
+      import TEST108._
+
+      shade[Assertion] { implicit c =>
+        overwrite[A108](A108_REPLACE)
+        inject[C108].provide.b.a.provide shouldBe A108_REPLACE
+      }
+
+      inject[C108].provide.b.a.provide shouldBe A108
+    }
   }
 
   "Tagging" should {

--- a/scaladia-container/src/test/scala/com/phylage/scaladia/InjectionTest.scala
+++ b/scaladia-container/src/test/scala/com/phylage/scaladia/InjectionTest.scala
@@ -176,7 +176,9 @@ object InjectionTest {
   object TEST108 {
 
     trait A108
+
     trait A108_TRAIT
+
     class A180_CLASS extends A108_TRAIT with AutoInject[A108_TRAIT]
 
     object A108_REPLACE extends A108
@@ -303,37 +305,37 @@ class InjectionTest extends AsyncWordSpec with Matchers with DiagrammedAssertion
 
     "recovered inject" in {
       import TEST2._
-      inject[TestIF_2].provide shouldBe TestIFImpl_2
+      inject[TestIF_2]._provide shouldBe TestIFImpl_2
     }
 
     "recovered vs default auto inject priority" in {
       import TEST3._
-      inject[TestIF_3].provide shouldBe TestIFImpl_3_AUTO
+      inject[TestIF_3]._provide shouldBe TestIFImpl_3_AUTO
     }
 
     "recovered vs custom(1) inject priority" in {
       import TEST4._
-      inject[TestIF_4].provide shouldBe TestIFImpl_4_CUSTOM
+      inject[TestIF_4]._provide shouldBe TestIFImpl_4_CUSTOM
     }
 
     "recovered vs custom(0) inject priority == name after win" in {
       import TEST5._
-      inject[TestIF_5].provide shouldBe TestIFImpl_5_RECOVER
+      inject[TestIF_5]._provide shouldBe TestIFImpl_5_RECOVER
     }
 
     "auto vs custom(999) inject priority == auto" in {
       import TEST6._
-      inject[TestIF_6].provide shouldBe TestIFImpl_6_AUTO
+      inject[TestIF_6]._provide shouldBe TestIFImpl_6_AUTO
     }
 
     "auto vs custom(1000) inject priority == name after win" in {
       import TEST7._
-      inject[TestIF_7].provide shouldBe TestIFImpl_7_CUSTOM
+      inject[TestIF_7]._provide shouldBe TestIFImpl_7_CUSTOM
     }
 
     "auto vs custom(1001) inject priority == custom" in {
       import TEST8._
-      inject[TestIF_8].provide shouldBe TestIFImpl_8_CUSTOM
+      inject[TestIF_8]._provide shouldBe TestIFImpl_8_CUSTOM
     }
   }
 
@@ -345,7 +347,7 @@ class InjectionTest extends AsyncWordSpec with Matchers with DiagrammedAssertion
 
       narrow[TestIF_101](LOCAL_TestIF_101).accept(this).indexing()
 
-      inject[TestIF_101].provide shouldBe LOCAL_TestIF_101
+      inject[TestIF_101]._provide shouldBe LOCAL_TestIF_101
     }
 
     "out of scope instance" in {
@@ -355,7 +357,7 @@ class InjectionTest extends AsyncWordSpec with Matchers with DiagrammedAssertion
 
       narrow[TestIF_102](LOCAL_TestIF_102).accept(TEST101.TestIFImpl_101_AUTO).indexing()
 
-      inject[TestIF_102].provide shouldBe TestIFImpl_102_AUTO
+      inject[TestIF_102]._provide shouldBe TestIFImpl_102_AUTO
     }
 
     "auto vs narrow class" in {
@@ -365,7 +367,7 @@ class InjectionTest extends AsyncWordSpec with Matchers with DiagrammedAssertion
 
       narrow[TestIF_103](LOCAL_TestIF_103).accept[InjectionTest].indexing()
 
-      inject[TestIF_103].provide shouldBe LOCAL_TestIF_103
+      inject[TestIF_103]._provide shouldBe LOCAL_TestIF_103
     }
 
     "out of scope class" in {
@@ -375,7 +377,7 @@ class InjectionTest extends AsyncWordSpec with Matchers with DiagrammedAssertion
 
       narrow[TestIF_104](LOCAL_TestIF_104).accept(TEST101.TestIFImpl_101_AUTO).indexing()
 
-      inject[TestIF_104].provide shouldBe TestIFImpl_104_AUTO
+      inject[TestIF_104]._provide shouldBe TestIFImpl_104_AUTO
     }
 
     "add scope of multiple types" in {
@@ -397,9 +399,9 @@ class InjectionTest extends AsyncWordSpec with Matchers with DiagrammedAssertion
 
       narrow[TestIF_105](LOCAL_TestIF_105).accept(AccessorA).accept(AccessorB).indexing()
 
-      AccessorA.get.provide shouldBe LOCAL_TestIF_105
-      AccessorB.get.provide shouldBe LOCAL_TestIF_105
-      AccessorC.get.provide shouldBe TestIFImpl_105_AUTO
+      AccessorA.get._provide shouldBe LOCAL_TestIF_105
+      AccessorB.get._provide shouldBe LOCAL_TestIF_105
+      AccessorC.get._provide shouldBe TestIFImpl_105_AUTO
     }
     "Meny acception class" in {
       import TEST106._
@@ -408,9 +410,9 @@ class InjectionTest extends AsyncWordSpec with Matchers with DiagrammedAssertion
 
       narrow[TestIF_106](LOCAL_TestIF_106).accept[AccessorTestA].accept[AccessorTestB].indexing()
 
-      AccessorA.get.provide shouldBe LOCAL_TestIF_106
-      AccessorB.get.provide shouldBe LOCAL_TestIF_106
-      AccessorC.get.provide shouldBe TestIFImpl_106_AUTO
+      AccessorA.get._provide shouldBe LOCAL_TestIF_106
+      AccessorB.get._provide shouldBe LOCAL_TestIF_106
+      AccessorC.get._provide shouldBe TestIFImpl_106_AUTO
     }
 
     "confirm vs narrow class" in {
@@ -430,25 +432,25 @@ class InjectionTest extends AsyncWordSpec with Matchers with DiagrammedAssertion
 
       shade[Assertion] { implicit c =>
         overwrite[A108](A108_REPLACE)
-        inject[C108].provide.b.a.provide shouldBe A108_REPLACE
+        inject[C108].b.a._provide shouldBe A108_REPLACE
       }
 
-      inject[C108].provide.b.a.provide shouldBe A108
+      inject[C108].b.a._provide shouldBe A108
     }
   }
 
   "Tagging" should {
     "tag inspect" in {
       import TEST201._
-      inject[TestIF_201].provide shouldBe TestIFImpl_201_TAGNONE
-      inject[TestIF_201 @@ TestTagA].provide shouldBe TestIFImpl_201_TAGA
-      inject[TestIF_201 @@ TestTagB].provide shouldBe TestIFImpl_201_TAGB
+      inject[TestIF_201]._provide shouldBe TestIFImpl_201_TAGNONE
+      inject[TestIF_201 @@ TestTagA]._provide shouldBe TestIFImpl_201_TAGA
+      inject[TestIF_201 @@ TestTagB]._provide shouldBe TestIFImpl_201_TAGB
 
       Try {
-        inject[TestIF_201 @@ TestTagC].provide
+        inject[TestIF_201 @@ TestTagC]._provide
       } match {
         case scala.util.Success(_) => fail()
-        case scala.util.Failure(exception) => exception.getMessage shouldBe "com.phylage.scaladia.Types.<refinement> or its internal initialize failed."
+        case scala.util.Failure(exception) => exception.getMessage shouldBe "interface com.phylage.scaladia.InjectionTest$TEST201$TestIF_201 or its internal initialize failed."
       }
     }
   }
@@ -460,9 +462,9 @@ class InjectionTest extends AsyncWordSpec with Matchers with DiagrammedAssertion
   "Inheritance relationship" should {
     "pattern 1" in {
       import TEST301._
-      inject[TestIF_301].provide shouldBe TestIFImpl_301_AUTO
+      inject[TestIF_301]._provide shouldBe TestIFImpl_301_AUTO
       Try {
-        inject[EX_TestIF_301].provide shouldBe TestIFImpl_301_AUTO
+        inject[EX_TestIF_301]._provide shouldBe TestIFImpl_301_AUTO
       } match {
         case scala.util.Failure(_: DIAutoInitializationException) => succeed
         case _ => fail()
@@ -470,9 +472,9 @@ class InjectionTest extends AsyncWordSpec with Matchers with DiagrammedAssertion
     }
     "pattern 2" in {
       import TEST302._
-      inject[TestIF_302].provide shouldBe TestIFImpl_302_AUTO
+      inject[TestIF_302]._provide shouldBe TestIFImpl_302_AUTO
       Try {
-        inject[EX_TestIF_302].provide shouldBe TestIFImpl_302_AUTO
+        inject[EX_TestIF_302]._provide shouldBe TestIFImpl_302_AUTO
       } match {
         case scala.util.Failure(_: DIAutoInitializationException) => succeed
         case _ => fail()
@@ -493,8 +495,8 @@ class InjectionTest extends AsyncWordSpec with Matchers with DiagrammedAssertion
       import scala.reflect.runtime.universe._
       def get[T <: TestIF : WeakTypeTag]: Lazy[Wrap_303[T]] = inject[Wrap_303[T]]
 
-      get[TestIF_303_A].provide shouldBe r_A
-      get[TestIF_303_B].provide shouldBe r_B
+      get[TestIF_303_A]._provide shouldBe r_A
+      get[TestIF_303_B]._provide shouldBe r_B
     }
 
     "type erase with Seq" in {
@@ -515,8 +517,8 @@ class InjectionTest extends AsyncWordSpec with Matchers with DiagrammedAssertion
       overwrite[Seq[TestIF_304_A]](r_A)
       overwrite[Seq[TestIF_304_B]](r_B)
 
-      inject[Seq[TestIF_304_A]].provide shouldBe r_A
-      inject[Seq[TestIF_304_B]].provide shouldBe r_B
+      inject[Seq[TestIF_304_A]]._provide shouldBe r_A
+      inject[Seq[TestIF_304_B]]._provide shouldBe r_B
     }
 
     "type erase with Auto" in {
@@ -525,8 +527,8 @@ class InjectionTest extends AsyncWordSpec with Matchers with DiagrammedAssertion
       import scala.reflect.runtime.universe._
       def get[T <: TestIF : WeakTypeTag]: Lazy[Wrap_305[T]] = inject[Wrap_305[T]]
 
-      get[TestIF_305_A].provide shouldBe TestIF_305_A_WRAP
-      get[TestIF_305_B].provide shouldBe TestIF_305_B_WRAP
+      get[TestIF_305_A]._provide shouldBe TestIF_305_A_WRAP
+      get[TestIF_305_B]._provide shouldBe TestIF_305_B_WRAP
     }
   }
 }

--- a/scaladia-container/version.sbt
+++ b/scaladia-container/version.sbt
@@ -1,1 +1,1 @@
-version in ThisProject := "2.3.1"
+version in ThisProject := "2.4.0"

--- a/scaladia-http/version.sbt
+++ b/scaladia-http/version.sbt
@@ -1,1 +1,1 @@
-version in ThisProject := "0.4.2"
+version in ThisProject := "0.5.0"

--- a/scaladia-lang/version.sbt
+++ b/scaladia-lang/version.sbt
@@ -1,1 +1,1 @@
-version in ThisProject := "1.3.2"
+version in ThisProject := "1.4.0"

--- a/scaladia-macro/src/main/scala/com/phylage/scaladia/container/Container.scala
+++ b/scaladia-macro/src/main/scala/com/phylage/scaladia/container/Container.scala
@@ -8,6 +8,9 @@ import com.phylage.scaladia.provider.Accessor
 import scala.reflect.runtime.universe._
 
 private[scaladia] trait Container {
+
+  val lights: Vector[Container]
+
   /**
     * Cache in the injection container.
     *
@@ -32,7 +35,7 @@ private[scaladia] trait Container {
     * @tparam T injection type
     * @return
     */
-  def createIndexer[T: WeakTypeTag](x: T, priority: Int): Indexer[T]
+  def createIndexer[T: WeakTypeTag](x: T, priority: Int, lights: Vector[Container] = this.lights): Indexer[T]
 
   def shading: Container @@ Localized
 }

--- a/scaladia-macro/src/main/scala/com/phylage/scaladia/injector/AutoInjectable.scala
+++ b/scaladia-macro/src/main/scala/com/phylage/scaladia/injector/AutoInjectable.scala
@@ -3,4 +3,5 @@ package com.phylage.scaladia.injector
 /**
   * This is subject to automatic loading by scaladia.
   */
-trait AutoInjectable[T]
+trait AutoInjectable[T] {
+}

--- a/scaladia-macro/src/main/scala/com/phylage/scaladia/injector/InjectionPool.scala
+++ b/scaladia-macro/src/main/scala/com/phylage/scaladia/injector/InjectionPool.scala
@@ -1,11 +1,12 @@
 package com.phylage.scaladia.injector
 
+import com.phylage.scaladia.container.Container
 import com.phylage.scaladia.injector.scope.InjectableScope
 
 import scala.reflect.runtime.universe._
 
 trait InjectionPool {
-  type InjectionApplyment[T] = () => InjectableScope[T]
+  type InjectionApplyment[T] = Container => InjectableScope[T]
 
   /**
     * Pool Injectable subtypes for automatic loading.

--- a/scaladia-macro/src/main/scala/com/phylage/scaladia/injector/InjectionType.scala
+++ b/scaladia-macro/src/main/scala/com/phylage/scaladia/injector/InjectionType.scala
@@ -1,12 +1,13 @@
 package com.phylage.scaladia.injector
 
+import com.phylage.scaladia.container.Container
 import com.phylage.scaladia.injector.scope.InjectableScope
 
 import scala.reflect.runtime.universe._
 
 object InjectionType {
-  def apply[T](applyment: () => InjectableScope[T], name: String)(implicit wtt: WeakTypeTag[T]): InjectionType[T] = InjectionType(wtt, applyment, name)
+  def apply[T](applyment: Container => InjectableScope[T], name: String)(implicit wtt: WeakTypeTag[T]): InjectionType[T] = InjectionType(wtt, applyment, name)
 }
-case class InjectionType[T](wtt: WeakTypeTag[T], applyment: () => InjectableScope[T], name: String) {
+case class InjectionType[T](wtt: WeakTypeTag[T], applyment: Container => InjectableScope[T], name: String) {
   def =:=[C](compare: InjectionType[C]): Boolean = name == compare.name
 }

--- a/scaladia-macro/src/main/scala/com/phylage/scaladia/internal/AutoDIExtractor.scala
+++ b/scaladia-macro/src/main/scala/com/phylage/scaladia/internal/AutoDIExtractor.scala
@@ -114,12 +114,12 @@ class AutoDIExtractor[C <: blackbox.Context](val c: C) {
     n.accessible match {
       case accessibleSymbol if accessibleSymbol.isEmpty => result
       case accessibleSymbol =>
-        accessibleSymbol
-          .filter(_.fullName.startsWith("com.phylage"))
-          .map(x => s"  ${x.companion} : ${x.companion.isClass} : ${!x.companion.isAbstract} :  ${
-            if (x.companion.isClass && !x.companion.isAbstract && x.companion.asClass.primaryConstructor.isMethod) {
-              x.companion.asClass.primaryConstructor.asMethod.paramLists
-            } else ""}").foreach(println)
+//        accessibleSymbol
+//          .filter(_.fullName.startsWith("com.phylage"))
+//          .map(x => s"  ${x.companion} : ${x.companion.isClass} : ${!x.companion.isAbstract} :  ${
+//            if (x.companion.isClass && !x.companion.isAbstract && x.companion.asClass.primaryConstructor.isMethod) {
+//              x.companion.asClass.primaryConstructor.asMethod.paramLists
+//            } else ""}").foreach(println)
         recursiveModuleExplore(
           accessibleSymbol.withFilter(_.isModule).flatMap(_.typeSignature.members).collect {
             case x if x.isModule => x

--- a/scaladia-macro/src/main/scala/com/phylage/scaladia/internal/AutoDIExtractor.scala
+++ b/scaladia-macro/src/main/scala/com/phylage/scaladia/internal/AutoDIExtractor.scala
@@ -95,7 +95,7 @@ class AutoDIExtractor[C <: blackbox.Context](val c: C) {
             None -> None
           case x if x.isPackage =>
             Some(x) -> None
-          case x if x.isModule && !x.isClass && !x.isAbstract =>
+          case x if x.isModule && !x.isAbstract =>
             None -> Some(x)
         } match {
           case x => x.flatMap(_._1) -> x.flatMap(_._2)
@@ -112,13 +112,19 @@ class AutoDIExtractor[C <: blackbox.Context](val c: C) {
   private final def recursiveModuleExplore(n: Vector[Symbol],
                                            result: Vector[Symbol] = Vector.empty): Vector[Symbol] = {
     n.accessible match {
-      case x if x.isEmpty => result
-      case accessible =>
+      case accessibleSymbol if accessibleSymbol.isEmpty => result
+      case accessibleSymbol =>
+        accessibleSymbol
+          .filter(_.fullName.startsWith("com.phylage"))
+          .map(x => s"  ${x.companion} : ${x.companion.isClass} : ${!x.companion.isAbstract} :  ${
+            if (x.companion.isClass && !x.companion.isAbstract && x.companion.asClass.primaryConstructor.isMethod) {
+              x.companion.asClass.primaryConstructor.asMethod.paramLists
+            } else ""}").foreach(println)
         recursiveModuleExplore(
-          accessible.flatMap(_.typeSignature.members).collect {
-            case x if x.isModule && !x.isClass => x
+          accessibleSymbol.withFilter(_.isModule).flatMap(_.typeSignature.members).collect {
+            case x if x.isModule => x
           },
-          result ++ accessible.filter(_.typeSignature.<:<(autoDITag)))
+          result ++ accessibleSymbol.filter(_.typeSignature.<:<(autoDITag)))
     }
   }
 

--- a/scaladia-macro/src/main/scala/com/phylage/scaladia/internal/InjectionCompound.scala
+++ b/scaladia-macro/src/main/scala/com/phylage/scaladia/internal/InjectionCompound.scala
@@ -5,6 +5,7 @@ import com.phylage.scaladia.injector.InjectionType
 import scala.reflect.macros.blackbox
 
 class InjectionCompound[C <: blackbox.Context](val c: C) {
+
   import c.universe._
 
   def build(symbols: Iterable[C#Symbol]): c.Expr[Iterable[InjectionType[_]]] = {
@@ -12,7 +13,7 @@ class InjectionCompound[C <: blackbox.Context](val c: C) {
     val flushed = symbols.map { name =>
       c.Expr[InjectionType[_]](
         q"""
-           com.phylage.scaladia.injector.InjectionType.apply(() => ${c.parse(name.fullName)}.flush, ${name.fullName})
+           com.phylage.scaladia.injector.InjectionType.apply(c => ${c.parse(name.fullName)}.flush(c), ${name.fullName})
          """
       )
     }

--- a/scaladia-macro/src/main/scala/com/phylage/scaladia/internal/LazyInitializer.scala
+++ b/scaladia-macro/src/main/scala/com/phylage/scaladia/internal/LazyInitializer.scala
@@ -1,8 +1,10 @@
 package com.phylage.scaladia.internal
 
 import com.phylage.scaladia.container.Container
+import com.phylage.scaladia.exception.{DIAutoInitializationException, InjectDefinitionException}
+import com.phylage.scaladia.injector.scope.InjectableScope
 import com.phylage.scaladia.injector.{InjectionPool, InjectionType}
-import com.phylage.scaladia.provider.Lazy
+import com.phylage.scaladia.provider.{Accessor, Lazy}
 
 import scala.reflect.macros.blackbox
 
@@ -10,36 +12,40 @@ class LazyInitializer[C <: blackbox.Context](val c: C) {
 
   import c.universe._
 
-  def lazyInit[T: C#WeakTypeTag](ctn: Tree, ip: Tree, access: c.Tree): Expr[Lazy[T]] = {
-    val tag = weakTypeOf[T]
-    c.Expr[Lazy[T]](
+  def lazyInit[T: c.WeakTypeTag](ctn: Tree, ip: Tree, access: c.Tree): Expr[Lazy[T]] = {
+    val injectionRf = c.Expr[T](
       q"""
-        {
-          ${publish(ip)}
-          ${c.Expr[InjectionPool](ip)}.collect[$tag].map(_.apply())
-          new com.phylage.scaladia.provider.Lazy[$tag] {
-            def provide: $tag = {
-              try {
-                ${injection[T](ctn, ip, access)}
-              } catch {
-                case e: java.lang.Throwable =>
-                  throw new com.phylage.scaladia.exception.DIAutoInitializationException(${tag.typeSymbol.fullName} + " or its internal initialize failed.", e)
-              }
-            }
-          }
-        }
+         ${injection[T](ctn, ip, access)} match {
+           case x: com.phylage.scaladia.injector.Injector =>
+             x._cntMutation = $ctn
+             x
+           case x => x
+         }
        """
     )
+
+    val typName = c.Expr {
+      c.reifyRuntimeClass(weakTypeOf[T])
+    }
+
+    reify[Lazy[T]] {
+      new Lazy[T] {
+        def _provide: T = try {
+          injectionRf.splice
+        } catch {
+          case e: Throwable =>
+            throw new DIAutoInitializationException(s"${typName.splice} or its internal initialize failed.", e)
+        }
+      }
+    }
   }
 
   def publish(ip: Tree): Expr[Unit] = {
-    c.Expr(
-      q"""
-        ${c.Expr[InjectionPool](ip)}.pool(
-          () => $scrapeInjectionTypes
-        )
-      """
-    )
+    reify {
+      c.Expr[InjectionPool](ip).splice.pool {
+        () => scrapeInjectionTypes.splice
+      }
+    }
   }
 
   def classpathRepooling[T: C#WeakTypeTag](fun: Tree, ip: Tree): Expr[T] = {
@@ -54,37 +60,48 @@ class LazyInitializer[C <: blackbox.Context](val c: C) {
   }
 
   def diligentInit[T: C#WeakTypeTag](ctn: Tree, ip: Tree, access: c.Tree): Expr[T] = {
-    val tag = weakTypeOf[T]
     c.Expr[T](
       q"""
          {
            ${publish(ip)}
-           ${c.Expr[InjectionPool](ip)}.collect[$tag].map(_.apply())
+           ${applymentFunctionTree[T](ctn, ip)}
            ${injection[T](ctn, ip, access)}
          }
        """
     )
   }
 
-  def injection[T: C#WeakTypeTag](ctn: Tree, ip: Tree, access: c.Tree): Expr[T] = {
-    val tag = weakTypeOf[T]
+  def injection[T: c.WeakTypeTag](ctn: Tree, ip: Tree, access: c.Tree): Expr[T] = {
 
-    val mayBeInjection = c.Expr[Option[T]](
-      q"""
-         ${c.Expr[Container](ctn)}.find[$tag]($access)
-       """
-    )
+    val ttagExpr = c.Expr {
+      c.reifyRuntimeClass(weakTypeOf[T])
+    }
 
-    c.Expr[T] {
-      q"""
-       $mayBeInjection getOrElse {
-         throw new com.phylage.scaladia.exception.InjectDefinitionException(s"Cannot found " + ${tag.typeSymbol.fullName} + " implementation.")
-       }
-     """
+    val mayBeInjection = reify {
+      c.Expr[Container](ctn).splice.find[T](
+        c.Expr[Accessor[_]](access).splice
+      )
+    }
+
+    reify {
+      mayBeInjection.splice orElse {
+        applymentFunctionTree[T](ctn, ip).splice
+        mayBeInjection.splice
+      } orElse {
+        publish(ip).splice
+        applymentFunctionTree[T](ctn, ip).splice
+        mayBeInjection.splice
+      } getOrElse {
+        throw new InjectDefinitionException(s"Cannot found ${ttagExpr.splice} implementations.")
+      }
     }
   }
 
-
+  private def applymentFunctionTree[T: WeakTypeTag](cnt: Tree, ip: Tree): c.Expr[Vector[InjectableScope[T]]] = {
+    reify {
+      c.Expr[InjectionPool](ip).splice.collect[T].map(_.apply(c.Expr[Container](cnt).splice))
+    }
+  }
 
   def scrapeInjectionTypes: c.Expr[Iterable[InjectionType[_]]] = {
     import c.universe._

--- a/scaladia-macro/src/main/scala/com/phylage/scaladia/provider/Lazy.scala
+++ b/scaladia-macro/src/main/scala/com/phylage/scaladia/provider/Lazy.scala
@@ -7,5 +7,5 @@ trait Lazy[X] {
     *
     * @return
     */
-  def provide: X
+  def _provide: X
 }

--- a/scaladia-macro/version.sbt
+++ b/scaladia-macro/version.sbt
@@ -1,1 +1,1 @@
-version in ThisProject := "1.3.1"
+version in ThisProject := "1.4.0"

--- a/test-across-module/call_interfaces/src/test/scala/com/phylage/scaladia/test/ModuleAcrossInjectionTest.scala
+++ b/test-across-module/call_interfaces/src/test/scala/com/phylage/scaladia/test/ModuleAcrossInjectionTest.scala
@@ -13,7 +13,7 @@ class ModuleAcrossInjectionTest extends AsyncWordSpec with Matchers with Diagram
         PureExecution.exec shouldBe ConfImpl.value
       } match {
         case Success(_) => fail("It can not be solved by the internal call which does not pass injection")
-        case Failure(e) => e.getMessage shouldBe "com.phylage.scaladia.test.Conf or its internal initialize failed."
+        case Failure(e) => e.getMessage shouldBe "interface com.phylage.scaladia.test.Conf or its internal initialize failed."
       }
     }
 


### PR DESCRIPTION
By using the shade function, it is possible to use a temporary container shade only inside that function. 
Using this, it is possible to overwrite dependencies without being aware of the scope.

```scala
    "using pattern" in {
      import TEST108._

      shade[Assertion] { implicit c =>
        overwrite[A108](A108_REPLACE)
        inject[C108].b.a._provide shouldBe A108_REPLACE
      }

      inject[C108].b.a._provide shouldBe A108
    }
```