### PR TITLE
V2.6.1 Effective injection bug fixes.

### DIFF
--- a/scaladia-container/README.md
+++ b/scaladia-container/README.md
@@ -1,7 +1,7 @@
 # scaladia-container
 
 ```
-libraryDependencies += "com.phylage" %% "scaladia-container" % "2.6.0"
+libraryDependencies += "com.phylage" %% "scaladia-container" % "2.6.1"
 ````
 
 # Common Usage

--- a/scaladia-container/src/main/scala/com/phylage/scaladia/container/StandardContainer.scala
+++ b/scaladia-container/src/main/scala/com/phylage/scaladia/container/StandardContainer.scala
@@ -53,7 +53,7 @@ class StandardContainer(buffer: ContainerPool = TrieMap.empty, val lights: Vecto
     buffer.get(ContainerIndexedKey(implicitly[WeakTypeTag[Effect]])) match {
       case None    => None
       case Some(x) =>
-        x.map(_.value.asInstanceOf[InjectableScope[Effect]])
+        x.map(_.asInstanceOf[InjectableScope[Effect]])
           .filter(_.value.activate)
           .toSeq
           .sortBy(_.priority)(Ordering.Int.reverse)

--- a/scaladia-container/version.sbt
+++ b/scaladia-container/version.sbt
@@ -1,1 +1,1 @@
-version in ThisProject := "2.6.0"
+version in ThisProject := "2.6.1"

--- a/scaladia-http/README.md
+++ b/scaladia-http/README.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```
-libraryDependencies += "com.phylage" %% "scaladia-http" % "0.6.4"
+libraryDependencies += "com.phylage" %% "scaladia-http" % "0.7.1"
 ````
 
 ## Examples

--- a/scaladia-http/version.sbt
+++ b/scaladia-http/version.sbt
@@ -1,1 +1,1 @@
-version in ThisProject := "0.7.0"
+version in ThisProject := "0.7.1"

--- a/scaladia-lang/version.sbt
+++ b/scaladia-lang/version.sbt
@@ -1,1 +1,1 @@
-version in ThisProject := "1.6.0"
+version in ThisProject := "1.6.1"


### PR DESCRIPTION
## Bug fix

Class cast exception occurs when multiple dependencies referencing the same Effect are accessed.

## Specification change

When there was an `@Effective` object, all objects that did not have an `@Effective` were not scanned.
From 2.6.1, Objects that do not have `@Effective` are scanned unconditionally.